### PR TITLE
Purge AQTS Capture SQS Queue before restarting db (IOW 586)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -26,7 +26,7 @@ custom:
     subnetIds: ${ssm:/iow/aws/vpc/${self:provider.stage}/subnetIds~split}
 
 functions:
-  startTestDb:
+  StartTestDb:
     handler: src.handler.start_test_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:

--- a/src/handler.py
+++ b/src/handler.py
@@ -6,8 +6,8 @@ QA_DB = 'nwcapture-qa'
 SQS_TEST = 'aqts-capture-trigger-queue-TEST'
 SQS_QA = 'aqts-capture-trigger-queue-QA'
 
-TEST_LAMBDA_TRIGGERS = ['aqts-capture-trigger-TEST-aqtsCaptureTrigger', 'aqts-capture-raw-load-TEST-iowCapture']
-QA_LAMBDA_TRIGGERS = ['aqts-capture-trigger-QA-aqtsCaptureTrigger', 'aqts-capture-raw-load-QA-iowCapture']
+TEST_LAMBDA_TRIGGERS = ['aqts-capture-trigger-TEST-aqtsCaptureTrigger']
+QA_LAMBDA_TRIGGERS = ['aqts-capture-trigger-QA-aqtsCaptureTrigger']
 
 
 def start_test_db(event, context):

--- a/src/utils.py
+++ b/src/utils.py
@@ -37,7 +37,7 @@ def purge_queue(queue_name):
     # Get the service resource
     sqs = boto3.client('sqs', os.getenv('AWS_DEPLOYMENT_REGION'))
     queue_info = sqs.get_queue_url(QueueName=queue_name)
-    sqs.purge_queue(queue_info['QueueUrl'])
+    sqs.purge_queue(QueueUrl=queue_info['QueueUrl'])
 
 
 def disable_triggers(function_names):

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,10 +4,8 @@ import boto3
 
 def describe_db_clusters(action):
     my_rds = boto3.client('rds', os.environ['AWS_DEPLOYMENT_REGION'])
-    print(f"my_rds {my_rds}")
     # Get all the instances
     response = my_rds.describe_db_clusters()
-    print(f"response {response}")
     all_dbs = response['DBClusters']
     if action == "start":
         # Filter on the one that are not running yet
@@ -37,8 +35,8 @@ def stop_db_cluster(cluster_identifier):
 
 def purge_queue(queue_name):
     # Get the service resource
-    sqs = boto3.resource('sqs', os.getenv('AWS_DEPLOYMENT_REGION'))
-    queue = sqs.get_queue_by_name(QueueName=queue_name)
+    sqs = boto3.client('sqs', os.getenv('AWS_DEPLOYMENT_REGION'))
+    queue = sqs.get_queue_url(QueueName=queue_name)
     sqs.purge_queue(queue.url)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -34,7 +34,6 @@ def stop_db_cluster(cluster_identifier):
 
 
 def purge_queue(queue_name):
-    # Get the service resource
     sqs = boto3.client('sqs', os.getenv('AWS_DEPLOYMENT_REGION'))
     queue_info = sqs.get_queue_url(QueueName=queue_name)
     sqs.purge_queue(QueueUrl=queue_info['QueueUrl'])

--- a/src/utils.py
+++ b/src/utils.py
@@ -36,8 +36,8 @@ def stop_db_cluster(cluster_identifier):
 def purge_queue(queue_name):
     # Get the service resource
     sqs = boto3.client('sqs', os.getenv('AWS_DEPLOYMENT_REGION'))
-    queue = sqs.get_queue_url(QueueName=queue_name)
-    sqs.purge_queue(queue.url)
+    queue_info = sqs.get_queue_url(QueueName=queue_name)
+    sqs.purge_queue(queue_info['QueueUrl'])
 
 
 def disable_triggers(function_names):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -41,9 +41,10 @@ class TestHandler(TestCase):
         self.context = {'element': 'lithium'}
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.utils.boto3.client', autospec=True)
+    @mock.patch('src.utils.boto3', autospec=True)
     def test_start_test_db_nothing_to_start(self, mock_boto):
         result = handler.start_test_db(self.initial_event, self.context)
+        mock_boto.resource.assert_called_once_with('sqs', 'us-south-10')
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the test db: False'
 
@@ -55,9 +56,10 @@ class TestHandler(TestCase):
         assert result['message'] == 'Stopped the test db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.utils.boto3.client', autospec=True)
+    @mock.patch('src.utils.boto3', autospec=True)
     def test_start_qa_db_nothing_to_start(self, mock_boto):
         result = handler.start_qa_db(self.initial_event, self.context)
+        mock_boto.resource.assert_called_once_with('sqs', 'us-south-10')
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the qa db: False'
 
@@ -69,29 +71,32 @@ class TestHandler(TestCase):
         assert result['message'] == 'Stopped the qa db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.utils.boto3.client', autospec=True)
+    @mock.patch('src.utils.boto3', autospec=True)
     def test_start_test_db_something_to_start(self, mock_boto):
         mock_rds = mock.Mock()
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-test'
         mock_rds.describe_db_clusters.return_value = my_mock_db_clusters
         mock_rds.start_db_cluster.return_value = {'nwcapture-test'}
-        mock_boto.return_value = mock_rds
+        mock_boto.client.return_value = mock_rds
         mock_rds.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.start_test_db(self.initial_event, self.context)
+        mock_boto.resource.assert_called_once_with('sqs', 'us-south-10')
+
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the test db: True'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.utils.boto3.client', autospec=True)
+    @mock.patch('src.utils.boto3', autospec=True)
     def test_start_qa_db_something_to_start(self, mock_boto):
         mock_rds = mock.Mock()
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-qa'
         mock_rds.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_boto.return_value = mock_rds
+        mock_boto.client.return_value = mock_rds
         mock_rds.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.start_qa_db(self.initial_event, self.context)
+        mock_boto.resource.assert_called_once_with('sqs', 'us-south-10')
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the qa db: True'
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -44,7 +44,6 @@ class TestHandler(TestCase):
     @mock.patch('src.utils.boto3', autospec=True)
     def test_start_test_db_nothing_to_start(self, mock_boto):
         result = handler.start_test_db(self.initial_event, self.context)
-        mock_boto.resource.assert_called_once_with('sqs', 'us-south-10')
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the test db: False'
 
@@ -59,7 +58,6 @@ class TestHandler(TestCase):
     @mock.patch('src.utils.boto3', autospec=True)
     def test_start_qa_db_nothing_to_start(self, mock_boto):
         result = handler.start_qa_db(self.initial_event, self.context)
-        mock_boto.resource.assert_called_once_with('sqs', 'us-south-10')
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the qa db: False'
 
@@ -81,7 +79,6 @@ class TestHandler(TestCase):
         mock_boto.client.return_value = mock_rds
         mock_rds.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.start_test_db(self.initial_event, self.context)
-        mock_boto.resource.assert_called_once_with('sqs', 'us-south-10')
 
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the test db: True'
@@ -96,7 +93,6 @@ class TestHandler(TestCase):
         mock_boto.client.return_value = mock_rds
         mock_rds.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.start_qa_db(self.initial_event, self.context)
-        mock_boto.resource.assert_called_once_with('sqs', 'us-south-10')
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the qa db: True'
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -69,14 +69,14 @@ class TestHandler(TestCase):
         assert result['message'] == 'Stopped the qa db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.utils.boto3', autospec=True)
+    @mock.patch('src.utils.boto3.client', autospec=True)
     def test_start_test_db_something_to_start(self, mock_boto):
         mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-test'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
         mock_client.start_db_cluster.return_value = {'nwcapture-test'}
-        mock_boto.client.return_value = mock_client
         mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.start_test_db(self.initial_event, self.context)
@@ -85,13 +85,13 @@ class TestHandler(TestCase):
         assert result['message'] == 'Started the test db: True'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.utils.boto3', autospec=True)
+    @mock.patch('src.utils.boto3.client', autospec=True)
     def test_start_qa_db_something_to_start(self, mock_boto):
         mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-qa'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_boto.client.return_value = mock_client
         mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.start_qa_db(self.initial_event, self.context)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -71,13 +71,14 @@ class TestHandler(TestCase):
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3', autospec=True)
     def test_start_test_db_something_to_start(self, mock_boto):
-        mock_rds = mock.Mock()
+        mock_client = mock.Mock()
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-test'
-        mock_rds.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_rds.start_db_cluster.return_value = {'nwcapture-test'}
-        mock_boto.client.return_value = mock_rds
-        mock_rds.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+        mock_client.start_db_cluster.return_value = {'nwcapture-test'}
+        mock_boto.client.return_value = mock_client
+        mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
+        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.start_test_db(self.initial_event, self.context)
 
         assert result['statusCode'] == 200
@@ -86,12 +87,13 @@ class TestHandler(TestCase):
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3', autospec=True)
     def test_start_qa_db_something_to_start(self, mock_boto):
-        mock_rds = mock.Mock()
+        mock_client = mock.Mock()
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-qa'
-        mock_rds.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_boto.client.return_value = mock_rds
-        mock_rds.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+        mock_boto.client.return_value = mock_client
+        mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
+        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.start_qa_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the qa db: True'
@@ -99,13 +101,13 @@ class TestHandler(TestCase):
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
     def test_stop_test_db_something_to_stop(self, mock_boto):
-        mock_rds = mock.Mock()
-        mock_boto.return_value = mock_rds
+        mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-test'
         my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
-        mock_rds.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_rds.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.stop_test_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == 'Stopped the test db: True'
@@ -113,13 +115,13 @@ class TestHandler(TestCase):
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
     def test_stop_qa_db_something_to_stop(self, mock_boto):
-        mock_rds = mock.Mock()
-        mock_boto.return_value = mock_rds
+        mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-qa'
         my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
-        mock_rds.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_rds.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         result = handler.stop_qa_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == 'Stopped the qa db: True'


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Purge SQS Queue and toggle raw load lambda trigger

Description
-----------
Original implementation of the ecosystem switch was:

1. enable/disable AQTS capture trigger
2. start/stop DB

But on Monday morning when the test DB started automatically there were many CloudWatch concurrency alarms for hours as the lambdas tried to process all the data that piled up over the weekend.  Since there will always be a large pile of old data when the test and QA dbs start up,  it would be better to reduce the number of alarms by purging the old data.

New approach:

1. enable/disable AQTS capture trigger
2. enable/disable raw load trigger
3. stop/start db
4. purge the AQTS capture SQS queue before starting the db.

In testing this new approach with the QA db, after startup only 2 QA alarms were triggered (compared to 5 for test db), and one QA alarm stopped after 5 minutes.  The raw load concurrency trigger is still going to happen because raw load is reading from S3 where S3 objects pile up (unless we decide go and delete them similar to the SQS purge).


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
