### PR TITLE
IOW-646 turn on/off observations db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - New repository
-- Add initial version of the stop and start lambdas for test and QA db clusters
+- Add initial version of the stop and start lambdas for nwcapture test and QA db clusters
+- Add initial version of the stop and start lambdas for observations test and QA db instances

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         }
     }
     parameters {
-        choice(choices: ['TEST'], description: 'Deploy Stage (i.e. tier)', name: 'DEPLOY_STAGE')
+        choice(choices: ['TEST', 'QA'], description: 'Deploy Stage (i.e. tier)', name: 'DEPLOY_STAGE')
     }
     triggers {
         pollSCM('H/5 * * * *')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-boto3==1.14.33
+boto3==1.15.1
+psycopg2-binary==2.8.6
+coverage==5.3

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,16 +21,17 @@ provider:
 custom:
   startObservationSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
-    QA: cron(0 12 ? * MON-FRI *)
   stopObservationSchedules:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
   startCaptureSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
-    QA: cron(0 12 ? * MON-FRI *)
   stopCaptureSchedules:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
+  startScheduleEnabled:
+    TEST: true
+    QA: false
 
   exportGitVariables: false
   accountNumber: ${ssm:/iow/aws/accountNumber}
@@ -53,7 +54,7 @@ functions:
     events:
       - schedule:
           rate: ${self:custom.startObservationSchedules.${self:provider.stage}}
-          enabled: true
+          enabled: ${self:custom.startScheduleEnabled.${self:provider.stage}}
     vpc: ${self:custom.vpc}
 
   StopObservationsDb:
@@ -82,7 +83,7 @@ functions:
     events:
       - schedule:
           rate: ${self:custom.startCaptureSchedules.${self:provider.stage}}
-          enabled: true
+          enabled: ${self:custom.startScheduleEnabled.${self:provider.stage}}
     vpc: ${self:custom.vpc}
 
   StopCaptureDb:

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,7 +31,7 @@ custom:
 functions:
 
   StopTestObservationDb:
-    handler.src.handler.stop_test_observations_db
+    handler: src.handler.stop_test_observations_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:
       DB_HOST: ${self:custom.db.connectInfo.DATABASE_ADDRESS}

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,21 @@ custom:
 
 functions:
 
+
+  StartObservationsDb:
+    handler: src.handler.start_observations_db
+    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
+      MAX_RETRIES: 6
+    events:
+      - schedule:
+          rate: cron(0 12 * * ? *)
+          #rate: cron(0 12 ? * MON-FRI *)
+          enabled: true
+    vpc: ${self:custom.vpc}
+
   StopObservationsDb:
     handler: src.handler.stop_observations_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
@@ -42,20 +57,8 @@ functions:
       STAGE: ${self:provider.stage}
     events:
       - schedule:
-          rate: cron(30 19 ? * MON-FRI *)
-          enabled: true
-    vpc: ${self:custom.vpc}
-
-  StartObservationsDb:
-    handler: src.handler.start_observations_db
-    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
-    environment:
-      AWS_DEPLOYMENT_REGION: ${self:provider.region}
-      STAGE: ${self:provider.stage}
-      MAX_RETRIES: 6
-    events:
-      - schedule:
-          rate: cron(0 20 ? * MON-FRI *)
+          rate: cron(0 23 * * ? *)
+          #rate: cron(0 23 ? * MON-FRI *)
           enabled: true
     vpc: ${self:custom.vpc}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,24 +24,66 @@ custom:
   vpc:
     securityGroupIds: ${ssm:/iow/retriever-capture/${self:provider.stage}/securityGroupIds~split}
     subnetIds: ${ssm:/iow/aws/vpc/${self:provider.stage}/subnetIds~split}
-  db:
-    connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-${self:provider.stage}~true}
+  testObservationsDb:
+    connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-TEST~true}
+  qaObservationsDb:
+    connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-QA~true}
 
 
 functions:
 
   StopTestObservationDb:
-    handler: src.handler.stop_test_observations_db
+    handler: src.handler.stop_observations_test_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:
-      DB_HOST: ${self:custom.db.connectInfo.DATABASE_ADDRESS}
-      DB_USER: ${self:custom.db.connectInfo.WQP_READ_ONLY_USERNAME}
-      DB_NAME: ${self:custom.db.connectInfo.DATABASE_NAME}
-      DB_PASSWORD: ${self:custom.db.connectInfo.WQP_READ_ONLY_PASSWORD}
+      DB_HOST: ${self:custom.testObservationsDb.connectInfo.DATABASE_ADDRESS}
+      DB_USER: ${self:custom.testObservationsDb.connectInfo.WQP_READ_ONLY_USERNAME}
+      DB_NAME: ${self:custom.testObservationsDb.connectInfo.DATABASE_NAME}
+      DB_PASSWORD: ${self:custom.testObservationsDb.connectInfo.WQP_READ_ONLY_PASSWORD}
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
     events:
       - schedule:
-          rate: rate(2 hours)
+          rate: cron(0 23 ? * MON-FRI *)
+          enabled: true
+    vpc: ${self:custom.vpc}
+
+  StopQaObservationDb:
+    handler: src.handler.stop_observations_qa_db
+    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
+    environment:
+      DB_HOST: ${self:custom.qaObservationsDb.connectInfo.DATABASE_ADDRESS}
+      DB_USER: ${self:custom.qaObservationsDb.connectInfo.WQP_READ_ONLY_USERNAME}
+      DB_NAME: ${self:custom.qaObservationsDb.connectInfo.DATABASE_NAME}
+      DB_PASSWORD: ${self:custom.qaObservationsDb.connectInfo.WQP_READ_ONLY_PASSWORD}
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+    events:
+      - schedule:
+          rate: cron(0 23 ? * MON-FRI *)
+          enabled: true
+    vpc: ${self:custom.vpc}
+
+  StartObservationsTestDb:
+    handler: src.handler.start_observations_test_db
+    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      MAX_RETRIES: 6
+    events:
+      - schedule:
+          rate: cron(0 12 ? * MON-FRI *)
+          enabled: true
+    vpc: ${self:custom.vpc}
+
+
+  StartObservationsQaDb:
+    handler: src.handler.start_observations_qa_db
+    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      MAX_RETRIES: 6
+    events:
+      - schedule:
+          rate: cron(0 12 ? * MON-FRI *)
           enabled: true
     vpc: ${self:custom.vpc}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,7 +42,7 @@ functions:
       STAGE: ${self:provider.stage}
     events:
       - schedule:
-          rate: cron(0 23 ? * MON-FRI *)
+          rate: cron(30 19 ? * MON-FRI *)
           enabled: true
     vpc: ${self:custom.vpc}
 
@@ -55,7 +55,7 @@ functions:
       MAX_RETRIES: 6
     events:
       - schedule:
-          rate: cron(0 12 ? * MON-FRI *)
+          rate: cron(0 20 ? * MON-FRI *)
           enabled: true
     vpc: ${self:custom.vpc}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,17 +21,20 @@ provider:
 custom:
   startObservationSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
+    QA: cron(0 14 ? * MON *)
   stopObservationSchedules:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
   startCaptureSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
+    QA: cron(0 14 ? * MON *)
   stopCaptureSchedules:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
   startScheduleEnabled:
     TEST: true
     QA: false
+
 
   exportGitVariables: false
   accountNumber: ${ssm:/iow/aws/accountNumber}

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,49 +24,34 @@ custom:
   vpc:
     securityGroupIds: ${ssm:/iow/retriever-capture/${self:provider.stage}/securityGroupIds~split}
     subnetIds: ${ssm:/iow/aws/vpc/${self:provider.stage}/subnetIds~split}
-  testObservationsDb:
-    connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-TEST~true}
-  qaObservationsDb:
-    connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-QA~true}
+  observationsDb:
+    connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-${self:provider.stage}~true}
 
 
 functions:
 
-  StopTestObservationDb:
-    handler: src.handler.stop_observations_test_db
+  StopObservationsDb:
+    handler: src.handler.stop_observations_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:
-      DB_HOST: ${self:custom.testObservationsDb.connectInfo.DATABASE_ADDRESS}
-      DB_USER: ${self:custom.testObservationsDb.connectInfo.WQP_READ_ONLY_USERNAME}
-      DB_NAME: ${self:custom.testObservationsDb.connectInfo.DATABASE_NAME}
-      DB_PASSWORD: ${self:custom.testObservationsDb.connectInfo.WQP_READ_ONLY_PASSWORD}
+      DB_HOST: ${self:custom.observationsDb.connectInfo.DATABASE_ADDRESS}
+      DB_USER: ${self:custom.observationsDb.connectInfo.WQP_READ_ONLY_USERNAME}
+      DB_NAME: ${self:custom.observationsDb.connectInfo.DATABASE_NAME}
+      DB_PASSWORD: ${self:custom.observationsDb.connectInfo.WQP_READ_ONLY_PASSWORD}
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
     events:
       - schedule:
           rate: cron(0 23 ? * MON-FRI *)
           enabled: true
     vpc: ${self:custom.vpc}
 
-  StopQaObservationDb:
-    handler: src.handler.stop_observations_qa_db
-    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
-    environment:
-      DB_HOST: ${self:custom.qaObservationsDb.connectInfo.DATABASE_ADDRESS}
-      DB_USER: ${self:custom.qaObservationsDb.connectInfo.WQP_READ_ONLY_USERNAME}
-      DB_NAME: ${self:custom.qaObservationsDb.connectInfo.DATABASE_NAME}
-      DB_PASSWORD: ${self:custom.qaObservationsDb.connectInfo.WQP_READ_ONLY_PASSWORD}
-      AWS_DEPLOYMENT_REGION: ${self:provider.region}
-    events:
-      - schedule:
-          rate: cron(0 23 ? * MON-FRI *)
-          enabled: true
-    vpc: ${self:custom.vpc}
-
-  StartObservationsTestDb:
-    handler: src.handler.start_observations_test_db
+  StartObservationsDb:
+    handler: src.handler.start_observations_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
       MAX_RETRIES: 6
     events:
       - schedule:
@@ -74,12 +59,12 @@ functions:
           enabled: true
     vpc: ${self:custom.vpc}
 
-
-  StartObservationsQaDb:
-    handler: src.handler.start_observations_qa_db
+  StartCaptureDb:
+    handler: src.handler.start_capture_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
       MAX_RETRIES: 6
     events:
       - schedule:
@@ -87,47 +72,16 @@ functions:
           enabled: true
     vpc: ${self:custom.vpc}
 
-  StartTestDb:
-    handler: src.handler.start_test_db
+  StopCaptureDb:
+    handler: src.handler.stop_capture_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
-      MAX_RETRIES: 6
-    events:
-      - schedule:
-          rate: cron(0 12 ? * MON-FRI *)
-          enabled: true
-    vpc: ${self:custom.vpc}
-
-  StopTestDb:
-    handler: src.handler.stop_test_db
-    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
-    environment:
-      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
       MAX_RETRIES: 6
     events:
       - schedule:
           rate: cron(0 23 ? * MON-FRI *)
-          enabled: true
-    vpc: ${self:custom.vpc}
-
-  StartQaDb:
-    handler: src.handler.start_qa_db
-    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
-    environment:
-      AWS_DEPLOYMENT_REGION: ${self:provider.region}
-      MAX_RETRIES: 6
-    vpc: ${self:custom.vpc}
-
-  StopQaDb:
-    handler: src.handler.stop_qa_db
-    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
-    environment:
-      AWS_DEPLOYMENT_REGION: ${self:provider.region}
-      MAX_RETRIES: 6
-    events:
-      - schedule:
-          rate: cron(0 23 ? * FRI *)
           enabled: true
     vpc: ${self:custom.vpc}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,6 +19,19 @@ provider:
     commitIdentifier: ${git:sha1}
 
 custom:
+  startObservationSchedules:
+    TEST: cron(0 22 ? * MON-FRI *)
+    QA: cron(0 22 ? * MON-FRI *)
+  stopObservationSchedules:
+    TEST: cron(30 21 ? * MON-FRI *)
+    QA: cron(0 23 ? * FRI *)
+  startCaptureSchedules:
+    TEST: cron(0 12 ? * MON-FRI *)
+    QA: cron(0 12 ? * MON-FRI *)
+  stopCaptureSchedules:
+    TEST: cron(0 23 ? * MON-FRI *)
+    QA: cron(0 23 ? * FRI *)
+
   exportGitVariables: false
   accountNumber: ${ssm:/iow/aws/accountNumber}
   vpc:
@@ -30,7 +43,6 @@ custom:
 
 functions:
 
-
   StartObservationsDb:
     handler: src.handler.start_observations_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
@@ -40,8 +52,7 @@ functions:
       MAX_RETRIES: 6
     events:
       - schedule:
-          rate: cron(0 12 * * ? *)
-          #rate: cron(0 12 ? * MON-FRI *)
+          rate: ${self:custom.startObservationSchedules.${self:provider.stage}}
           enabled: true
     vpc: ${self:custom.vpc}
 
@@ -57,8 +68,7 @@ functions:
       STAGE: ${self:provider.stage}
     events:
       - schedule:
-          rate: cron(0 23 * * ? *)
-          #rate: cron(0 23 ? * MON-FRI *)
+          rate: ${self:custom.startObservationSchedules.${self:provider.stage}}
           enabled: true
     vpc: ${self:custom.vpc}
 
@@ -71,7 +81,7 @@ functions:
       MAX_RETRIES: 6
     events:
       - schedule:
-          rate: cron(0 12 ? * MON-FRI *)
+          rate: ${self:custom.startCaptureSchedules.${self:provider.stage}}
           enabled: true
     vpc: ${self:custom.vpc}
 
@@ -84,10 +94,9 @@ functions:
       MAX_RETRIES: 6
     events:
       - schedule:
-          rate: cron(0 23 ? * MON-FRI *)
+          rate: ${self:custom.stopCaptureSchedules.${self:provider.stage}}
           enabled: true
     vpc: ${self:custom.vpc}
-
 
 plugins:
   - serverless-plugin-git-variables

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,9 +35,9 @@ functions:
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:
       DB_HOST: ${self:custom.db.connectInfo.DATABASE_ADDRESS}
-      DB_USER: ${self:custom.db.connectInfo.SCHEMA_OWNER_USERNAME}
+      DB_USER: ${self:custom.db.connectInfo.WQP_READ_ONLY_USERNAME}
       DB_NAME: ${self:custom.db.connectInfo.DATABASE_NAME}
-      DB_PASSWORD: ${self:custom.db.connectInfo.SCHEMA_OWNER_PASSWORD}
+      DB_PASSWORD: ${self:custom.db.connectInfo.WQP_READ_ONLY_PASSWORD}
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
     events:
       - schedule:

--- a/serverless.yml
+++ b/serverless.yml
@@ -68,7 +68,7 @@ functions:
       STAGE: ${self:provider.stage}
     events:
       - schedule:
-          rate: ${self:custom.startObservationSchedules.${self:provider.stage}}
+          rate: ${self:custom.stopObservationSchedules.${self:provider.stage}}
           enabled: true
     vpc: ${self:custom.vpc}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,7 +6,7 @@ provider:
   stage: ${opt:stage, 'TEST'}
   runtime: python3.8
   memorySize: 128
-  timeout: 45
+  timeout: 30
   logRetentionInDays: 90
   deploymentBucket:
     name: iow-cloud-applications
@@ -20,10 +20,10 @@ provider:
 
 custom:
   startObservationSchedules:
-    TEST: cron(0 22 ? * MON-FRI *)
-    QA: cron(0 22 ? * MON-FRI *)
+    TEST: cron(0 12 ? * MON-FRI *)
+    QA: cron(0 12 ? * MON-FRI *)
   stopObservationSchedules:
-    TEST: cron(30 21 ? * MON-FRI *)
+    TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
   startCaptureSchedules:
     TEST: cron(0 12 ? * MON-FRI *)

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,8 +24,27 @@ custom:
   vpc:
     securityGroupIds: ${ssm:/iow/retriever-capture/${self:provider.stage}/securityGroupIds~split}
     subnetIds: ${ssm:/iow/aws/vpc/${self:provider.stage}/subnetIds~split}
+  db:
+    connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-${self:provider.stage}~true}
+
 
 functions:
+
+  StopTestObservationDb:
+    handler.src.handler.stop_test_observations_db
+    role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
+    environment:
+      DB_HOST: ${self:custom.db.connectInfo.DATABASE_ADDRESS}
+      DB_USER: ${self:custom.db.connectInfo.SCHEMA_OWNER_USERNAME}
+      DB_NAME: ${self:custom.db.connectInfo.DATABASE_NAME}
+      DB_PASSWORD: ${self:custom.db.connectInfo.SCHEMA_OWNER_PASSWORD}
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+    events:
+      - schedule:
+          rate: rate(2 hours)
+          enabled: true
+    vpc: ${self:custom.vpc}
+
   StartTestDb:
     handler: src.handler.start_test_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role

--- a/src/config.py
+++ b/src/config.py
@@ -20,7 +20,7 @@ CONFIG = {
         'port': env('DB_PORT', '5432'),
         'database': env('DB_NAME', 'retriever_capture'),
         # default to postgres but could be a schema owner instead
-        'user': env('DB_USER', 'postgres'),
-        'password': env('DB_PASSWORD')
+        'user': env('WQP_READ_ONLY_USERNAME', 'postgres'),
+        'password': env('WQP_READ_ONLY_PASSWORD')
     }
 }

--- a/src/config.py
+++ b/src/config.py
@@ -19,8 +19,7 @@ CONFIG = {
         'host': env('DB_HOST'),
         'port': env('DB_PORT'),
         'database': env('DB_NAME'),
-        # default to postgres but could be a schema owner instead
-        'user': env('WQP_READ_ONLY_USERNAME'),
-        'password': env('WQP_READ_ONLY_PASSWORD')
+        'user': env('DB_USER'),
+        'password': env('DB_PASSWORD')
     }
 }

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,26 @@
+import os
+
+
+def env(param, default_value=""):
+    """ convenience method for fetching environment values """
+    if default_value == "":
+        default_value = f'{param} is not set'
+    return os.environ.get(param, default_value)
+
+
+""" AWS configuration from environment """
+CONFIG = {
+    'aws': {
+        # everything is in one region right now
+        'region': env('AWS_DEPLOYMENT_REGION', 'us-west-2'),
+        'endpoint-base': env('AWS-BASE-ENDPOINT', '.c8adwxz9sely.us-west-2.rds.amazonaws.com'),
+    },
+    'rds': {
+        'host': env('DB_HOST'),
+        'port': env('DB_PORT', '5432'),
+        'database': env('DB_NAME', 'retriever_capture'),
+        # default to postgres but could be a schema owner instead
+        'user': env('DB_USER', 'postgres'),
+        'password': env('DB_PASSWORD')
+    }
+}

--- a/src/config.py
+++ b/src/config.py
@@ -17,10 +17,10 @@ CONFIG = {
     },
     'rds': {
         'host': env('DB_HOST'),
-        'port': env('DB_PORT', '5432'),
-        'database': env('DB_NAME', 'retriever_capture'),
+        'port': env('DB_PORT'),
+        'database': env('DB_NAME'),
         # default to postgres but could be a schema owner instead
-        'user': env('WQP_READ_ONLY_USERNAME', 'postgres'),
+        'user': env('WQP_READ_ONLY_USERNAME'),
         'password': env('WQP_READ_ONLY_PASSWORD')
     }
 }

--- a/src/handler.py
+++ b/src/handler.py
@@ -82,7 +82,12 @@ def stop_test_observations_db(event, context):
 
     logger.debug(f"about to run query {sql}")
     result = rds.execute_sql(sql)
-    logger.debug(f"query ran with result {result}")
+    if result[0] > 0:
+        logger.debug("something is running")
+    elif result[0] == 0:
+        logger.debug("nothing is running")
+    else:
+        raise Exception(f"something wrong with db result {result}")
     # boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observation-test')
 
     logger.debug("exit stop_test_observations_db")

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime
 
 import boto3
 from src.rds import RDS
@@ -34,16 +33,10 @@ def start_capture_db(event, context):
 
 
 def stop_capture_db(event, context):
-    stopped = False
     if os.getenv('STAGE') == 'TEST':
         stopped = _stop_db(TEST_DB, TEST_LAMBDA_TRIGGERS)
     elif os.getenv('STAGE') == 'QA':
-        # The QA db only shuts down automatically on Fridays
-        day_of_week = datetime.today().weekday()
-        if day_of_week == 4:
-            stopped = _stop_db(QA_DB, QA_LAMBDA_TRIGGERS)
-        else:
-            stopped = "Did not stop QA database because today is not Friday"
+        stopped = _stop_db(QA_DB, QA_LAMBDA_TRIGGERS)
     else:
         raise Exception(f"stage not recognized {os.getenv('STAGE')}")
     return {
@@ -90,8 +83,6 @@ def start_observations_db(event, context):
         boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-test')
     elif os.getenv('STAGE') == 'QA':
         boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-qa')
-    else:
-        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
 
 
 def _run_query():

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,3 +1,5 @@
+import os
+
 from src.config import CONFIG
 from src.rds import RDS
 from src.utils import enable_triggers, describe_db_clusters, start_db_cluster, disable_triggers, stop_db_cluster, \
@@ -75,10 +77,7 @@ def stop_db(db, triggers):
 def stop_test_observations_db(event, context):
     logger.debug("enter stop_test_observations_db")
     # 1. query the
-    logger.debug(f"host {CONFIG['rds']['host']}")
-    logger.debug(f"host {CONFIG['rds']['database']}")
-    logger.debug(f"host {CONFIG['rds']['user']}")
-
+    logger.debug(os.environ)
     sql = "select count(1) from batch_job_execution where status not in ('COMPLETED', 'FAILED')"
     rds = RDS()
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,5 +1,7 @@
+from src.rds import RDS
 from src.utils import enable_triggers, describe_db_clusters, start_db_cluster, disable_triggers, stop_db_cluster, \
     purge_queue
+import logging
 
 TEST_DB = 'nwcapture-test'
 QA_DB = 'nwcapture-qa'
@@ -9,6 +11,9 @@ SQS_QA = 'aqts-capture-trigger-queue-QA'
 TEST_LAMBDA_TRIGGERS = ['aqts-capture-trigger-TEST-aqtsCaptureTrigger',
                         'aqts-capture-trigger-tmp-TEST-aqtsCaptureTrigger']
 QA_LAMBDA_TRIGGERS = ['aqts-capture-trigger-QA-aqtsCaptureTrigger']
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 def start_test_db(event, context):
@@ -64,3 +69,18 @@ def stop_db(db, triggers):
             stop_db_cluster(db)
             stopped = True
     return stopped
+
+
+def stop_test_observations_db(event, context):
+    logger.debug("enter stop_test_observations_db")
+    # 1. query the
+
+    sql = "select count(1) from batch_job_execution where status not in ('COMPLETED', 'FAILED')"
+    rds = RDS()
+
+    logger.debug(f"about to run query {sql}")
+    result = rds.execute_sql(sql)
+    logger.debug(f"query ran with result {result}")
+    # boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observation-test')
+
+    logger.debug("exit stop_test_observations_db")

--- a/src/handler.py
+++ b/src/handler.py
@@ -8,11 +8,9 @@ TEST_DB = 'nwcapture-test'
 QA_DB = 'nwcapture-qa'
 SQS_TEST = 'aqts-capture-trigger-queue-TEST'
 SQS_QA = 'aqts-capture-trigger-queue-QA'
-
-TEST_LAMBDA_TRIGGERS = ['aqts-capture-trigger-TEST-aqtsCaptureTrigger',
-                        'aqts-capture-trigger-tmp-TEST-aqtsCaptureTrigger']
+TEST_LAMBDA_TRIGGERS = [
+    'aqts-capture-trigger-TEST-aqtsCaptureTrigger', 'aqts-capture-trigger-tmp-TEST-aqtsCaptureTrigger']
 QA_LAMBDA_TRIGGERS = ['aqts-capture-trigger-QA-aqtsCaptureTrigger']
-
 SQL = "select count(1) from batch_job_execution where status not in ('COMPLETED', 'FAILED')"
 
 logger = logging.getLogger(__name__)
@@ -76,20 +74,20 @@ def stop_db(db, triggers):
 
 def stop_observations_test_db(event, context):
     _run_query()
-    boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observation-test')
+    boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observations-test')
 
 
 def start_observations_test_db(event, context):
-    boto3.client('rds').start_db_instance(DBInstanceIdentifier='observation-test')
+    boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-test')
 
 
 def start_observations_qa_db(event, context):
-    boto3.client('rds').start_db_instance(DBInstanceIdentifier='observation-qa')
+    boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-qa')
 
 
 def stop_observations_qa_db(event, context):
     _run_query()
-    boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observation-qa')
+    boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observations-qa')
 
 
 def _run_query():

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,3 +1,5 @@
+import os
+
 import boto3
 from src.rds import RDS
 from src.utils import enable_triggers, describe_db_clusters, start_db_cluster, disable_triggers, stop_db_cluster, \
@@ -17,39 +19,33 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def start_test_db(event, context):
-    started = start_db(TEST_DB, TEST_LAMBDA_TRIGGERS, SQS_TEST)
+def start_capture_db(event, context):
+    if os.getenv('STAGE') == 'TEST':
+        started = _start_db(TEST_DB, TEST_LAMBDA_TRIGGERS, SQS_TEST)
+    elif os.getenv('STAGE') == 'QA':
+        started = _start_db(QA_DB, QA_LAMBDA_TRIGGERS, SQS_QA)
+    else:
+        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
     return {
         'statusCode': 200,
-        'message': f"Started the test db: {started}"
+        'message': f"Started the {os.getenv('STAGE')} db: {started}"
     }
 
 
-def start_qa_db(event, context):
-    started = start_db(QA_DB, QA_LAMBDA_TRIGGERS, SQS_QA)
+def stop_capture_db(event, context):
+    if os.getenv('STAGE') == 'TEST':
+        stopped = _stop_db(TEST_DB, TEST_LAMBDA_TRIGGERS)
+    elif os.getenv('STAGE') == 'QA':
+        stopped = _stop_db(QA_DB, QA_LAMBDA_TRIGGERS)
+    else:
+        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
     return {
         'statusCode': 200,
-        'message': f"Started the qa db: {started}"
+        'message': f"Stopped the {os.getenv('STAGE')} db: {stopped}"
     }
 
 
-def stop_test_db(event, context):
-    stopped = stop_db(TEST_DB, TEST_LAMBDA_TRIGGERS)
-    return {
-        'statusCode': 200,
-        'message': f"Stopped the test db: {stopped}"
-    }
-
-
-def stop_qa_db(event, context):
-    stopped = stop_db(QA_DB, QA_LAMBDA_TRIGGERS)
-    return {
-        'statusCode': 200,
-        'message': f"Stopped the qa db: {stopped}"
-    }
-
-
-def start_db(db, triggers, queue_name):
+def _start_db(db, triggers, queue_name):
     purge_queue(queue_name)
     cluster_identifiers = describe_db_clusters("start")
     started = False
@@ -61,7 +57,7 @@ def start_db(db, triggers, queue_name):
     return started
 
 
-def stop_db(db, triggers):
+def _stop_db(db, triggers):
     cluster_identifiers = describe_db_clusters("stop")
     stopped = False
     disable_triggers(triggers)
@@ -72,22 +68,23 @@ def stop_db(db, triggers):
     return stopped
 
 
-def stop_observations_test_db(event, context):
+def stop_observations_db(event, context):
     _run_query()
-    boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observations-test')
+    if os.getenv('STAGE') == 'TEST':
+        boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observations-test')
+    elif os.getenv('STAGE') == 'QA':
+        boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observations-qa')
+    else:
+        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
 
 
-def start_observations_test_db(event, context):
-    boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-test')
-
-
-def start_observations_qa_db(event, context):
-    boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-qa')
-
-
-def stop_observations_qa_db(event, context):
-    _run_query()
-    boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observations-qa')
+def start_observations_db(event, context):
+    if os.getenv('STAGE') == 'TEST':
+        boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-test')
+    elif os.getenv('STAGE') == 'QA':
+        boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-qa')
+    else:
+        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
 
 
 def _run_query():

--- a/src/handler.py
+++ b/src/handler.py
@@ -77,7 +77,7 @@ def stop_db(db, triggers):
 def stop_test_observations_db(event, context):
     logger.debug("enter stop_test_observations_db")
     # 1. query the
-    sql = "select count(1) from batch_job_execution where status not in ('COMPLETED', 'FAILED')"
+    sql = "select count(1) from batch_job_execution where status not in ('COMPLETED')"
     rds = RDS()
 
     logger.debug(f"about to run query {sql}")

--- a/src/handler.py
+++ b/src/handler.py
@@ -77,7 +77,6 @@ def stop_db(db, triggers):
 def stop_test_observations_db(event, context):
     logger.debug("enter stop_test_observations_db")
     # 1. query the
-    logger.debug(os.environ)
     sql = "select count(1) from batch_job_execution where status not in ('COMPLETED', 'FAILED')"
     rds = RDS()
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 
 import boto3
 from src.rds import RDS
@@ -33,10 +34,16 @@ def start_capture_db(event, context):
 
 
 def stop_capture_db(event, context):
+    stopped = False
     if os.getenv('STAGE') == 'TEST':
         stopped = _stop_db(TEST_DB, TEST_LAMBDA_TRIGGERS)
     elif os.getenv('STAGE') == 'QA':
-        stopped = _stop_db(QA_DB, QA_LAMBDA_TRIGGERS)
+        # The QA db only shuts down automatically on Fridays
+        day_of_week = datetime.today().weekday()
+        if day_of_week == 4:
+            stopped = _stop_db(QA_DB, QA_LAMBDA_TRIGGERS)
+        else:
+            stopped = "Did not stop QA database because today is not Friday"
     else:
         raise Exception(f"stage not recognized {os.getenv('STAGE')}")
     return {

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,3 +1,4 @@
+from src.config import CONFIG
 from src.rds import RDS
 from src.utils import enable_triggers, describe_db_clusters, start_db_cluster, disable_triggers, stop_db_cluster, \
     purge_queue
@@ -74,6 +75,9 @@ def stop_db(db, triggers):
 def stop_test_observations_db(event, context):
     logger.debug("enter stop_test_observations_db")
     # 1. query the
+    logger.debug(f"host {CONFIG['rds']['host']}")
+    logger.debug(f"host {CONFIG['rds']['database']}")
+    logger.debug(f"host {CONFIG['rds']['user']}")
 
     sql = "select count(1) from batch_job_execution where status not in ('COMPLETED', 'FAILED')"
     rds = RDS()

--- a/src/rds.py
+++ b/src/rds.py
@@ -5,9 +5,6 @@ This module manages persisting data from a message into the RDS Resource.
 # the postgresql connection module
 from psycopg2 import connect
 from psycopg2 import OperationalError, DataError, IntegrityError
-# json allows us to convert between dictionaries and json.
-import json
-import datetime
 
 # project specific configuration parameters.
 from .config import CONFIG
@@ -17,7 +14,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
 
 
 class RDS:
@@ -63,4 +59,3 @@ class RDS:
         except (OperationalError, DataError, IntegrityError) as e:
             logger.debug(f'Error during SQL execution: {repr(e)}', exc_info=True)
             self.conn.rollback()
-

--- a/src/rds.py
+++ b/src/rds.py
@@ -38,6 +38,7 @@ class RDS:
             # keyword argument from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
 
         }
+
         logger.debug("created RDS instance %s" % self.connection_parameters)
         self.conn, self.cursor = self._connect()
 

--- a/src/rds.py
+++ b/src/rds.py
@@ -1,0 +1,69 @@
+"""
+This module manages persisting data from a message into the RDS Resource.
+"""
+
+# the postgresql connection module
+from psycopg2 import connect
+from psycopg2 import OperationalError, DataError, IntegrityError
+# json allows us to convert between dictionaries and json.
+import json
+import datetime
+
+# project specific configuration parameters.
+from .config import CONFIG
+
+# allows for logging information
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+
+class RDS:
+
+    def __init__(self, connect_timeout=65):
+        """
+        connect to the database resource.
+
+        wait for 50 seconds before giving up on getting a connection
+
+        """
+        self.connection_parameters = {
+            'host': CONFIG['rds']['host'],
+            'database': CONFIG['rds']['database'],
+            'user': CONFIG['rds']['user'],
+            'password': CONFIG['rds']['password'],
+            'connect_timeout': connect_timeout
+            # keyword argument from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+
+        }
+        logger.debug("created RDS instance %s" % self.connection_parameters)
+        self.conn, self.cursor = self._connect()
+
+    def _connect(self):
+        conn = connect(**self.connection_parameters)  # should raise a OperationalError if it can't get a connection
+        # Interestingly, autocommit seemed necessary for create table too.
+        conn.autocommit = True
+        cursor = conn.cursor()
+        return conn, cursor
+
+    def disconnect(self):
+        try:
+            self.conn.close()
+            logger.debug(f'Disconnected from database: {self.conn}.')
+        except AttributeError as e:
+            # Would be surprised if this ever gets thrown.
+            # An exception should be thrown well before this.
+            logger.debug(f'Error closing connection objection: {repr(e)}', exc_info=True)
+            raise RuntimeError
+
+    def execute_sql(self, sql):
+        # logger.debug(f'SQL: {self.cursor.mogrify(sql)}.')
+        try:
+            return self.cursor.execute(sql)
+        except (OperationalError, DataError, IntegrityError) as e:
+            logger.debug(f'Error during SQL execution: {repr(e)}', exc_info=True)
+            logger.debug('Transaction will be rolled back.')
+            self.conn.rollback()
+

--- a/src/rds.py
+++ b/src/rds.py
@@ -62,7 +62,8 @@ class RDS:
     def execute_sql(self, sql):
         # logger.debug(f'SQL: {self.cursor.mogrify(sql)}.')
         try:
-            return self.cursor.execute(sql)
+            self.cursor.execute(sql)
+            return self.cursor.fetchone()
         except (OperationalError, DataError, IntegrityError) as e:
             logger.debug(f'Error during SQL execution: {repr(e)}', exc_info=True)
             logger.debug('Transaction will be rolled back.')

--- a/src/rds.py
+++ b/src/rds.py
@@ -25,9 +25,7 @@ class RDS:
     def __init__(self, connect_timeout=65):
         """
         connect to the database resource.
-
         wait for 50 seconds before giving up on getting a connection
-
         """
         self.connection_parameters = {
             'host': CONFIG['rds']['host'],
@@ -36,7 +34,6 @@ class RDS:
             'password': CONFIG['rds']['password'],
             'connect_timeout': connect_timeout
             # keyword argument from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-
         }
 
         logger.debug("created RDS instance %s" % self.connection_parameters)
@@ -60,12 +57,10 @@ class RDS:
             raise RuntimeError
 
     def execute_sql(self, sql):
-        # logger.debug(f'SQL: {self.cursor.mogrify(sql)}.')
         try:
             self.cursor.execute(sql)
             return self.cursor.fetchone()
         except (OperationalError, DataError, IntegrityError) as e:
             logger.debug(f'Error during SQL execution: {repr(e)}', exc_info=True)
-            logger.debug('Transaction will be rolled back.')
             self.conn.rollback()
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase, mock
 
 from src import handler
@@ -43,30 +44,34 @@ class TestHandler(TestCase):
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3', autospec=True)
     def test_start_test_db_nothing_to_start(self, mock_boto):
-        result = handler.start_test_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'TEST'
+        result = handler.start_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Started the test db: False'
+        assert result['message'] == 'Started the TEST db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
     def test_stop_test_db_nothing_to_stop(self, mock_boto):
-        result = handler.stop_test_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'TEST'
+        result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the test db: False'
+        assert result['message'] == 'Stopped the TEST db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3', autospec=True)
     def test_start_qa_db_nothing_to_start(self, mock_boto):
-        result = handler.start_qa_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'QA'
+        result = handler.start_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Started the qa db: False'
+        assert result['message'] == 'Started the QA db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
     def test_stop_qa_db_nothing_to_stop(self, mock_boto):
-        result = handler.stop_qa_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'QA'
+        result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the qa db: False'
+        assert result['message'] == 'Stopped the QA db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
@@ -79,10 +84,11 @@ class TestHandler(TestCase):
         mock_client.start_db_cluster.return_value = {'nwcapture-test'}
         mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        result = handler.start_test_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'TEST'
+        result = handler.start_capture_db(self.initial_event, self.context)
 
         assert result['statusCode'] == 200
-        assert result['message'] == 'Started the test db: True'
+        assert result['message'] == 'Started the TEST db: True'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
@@ -94,9 +100,10 @@ class TestHandler(TestCase):
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
         mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        result = handler.start_qa_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'QA'
+        result = handler.start_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Started the qa db: True'
+        assert result['message'] == 'Started the QA db: True'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
@@ -108,9 +115,10 @@ class TestHandler(TestCase):
         my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        result = handler.stop_test_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'TEST'
+        result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the test db: True'
+        assert result['message'] == 'Stopped the TEST db: True'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
@@ -122,6 +130,7 @@ class TestHandler(TestCase):
         my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        result = handler.stop_qa_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'QA'
+        result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the qa db: True'
+        assert result['message'] == 'Stopped the QA db: True'

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 from unittest import TestCase, mock
 
@@ -72,11 +71,7 @@ class TestHandler(TestCase):
         os.environ['STAGE'] = 'QA'
         result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        day_of_week = datetime.datetime.today().weekday()
-        if day_of_week == 4:
-            assert result['message'] == 'Stopped the QA db: True'
-        else:
-            assert result['message'] == 'Stopped the QA db: Did not stop QA database because today is not Friday'
+        assert result['message'] == 'Stopped the QA db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
@@ -138,8 +133,4 @@ class TestHandler(TestCase):
         os.environ['STAGE'] = 'QA'
         result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        day_of_week = datetime.datetime.today().weekday()
-        if day_of_week == 4:
-            assert result['message'] == 'Stopped the QA db: True'
-        else:
-            assert result['message'] == 'Stopped the QA db: Did not stop QA database because today is not Friday'
+        assert result['message'] == 'Stopped the QA db: True'

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -74,6 +74,64 @@ class TestHandler(TestCase):
         assert result['message'] == 'Stopped the QA db: False'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler._run_query')
+    @mock.patch('src.utils.boto3.client', autospec=True)
+    def test_stop_observations_qa_db_dont_stop_busy(self, mock_boto, mock_rds):
+        mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
+        mock_rds.return_value = False
+        os.environ['STAGE'] = 'QA'
+        result = handler.stop_observations_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == "Could not stop the QA observations db. It was busy."
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler._run_query')
+    @mock.patch('src.utils.boto3.client', autospec=True)
+    def test_stop_observations_test_db_dont_stop_busy(self, mock_boto, mock_rds):
+        mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
+        mock_rds.return_value = False
+        os.environ['STAGE'] = 'TEST'
+        result = handler.stop_observations_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == "Could not stop the TEST observations db. It was busy."
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler._run_query')
+    @mock.patch('src.utils.boto3.client', autospec=True)
+    def test_stop_observations_db_unknown_stage(self, mock_boto, mock_rds):
+        mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
+        mock_rds.return_value = False
+        with self.assertRaises(Exception) as context:
+            handler.stop_observations_db(self.initial_event, self.context)
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler._run_query')
+    @mock.patch('src.utils.boto3.client', autospec=True)
+    def test_stop_observations_qa_db_stop_quiet(self, mock_boto, mock_rds):
+        mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
+        mock_rds.return_value = True
+        os.environ['STAGE'] = 'QA'
+        result = handler.stop_observations_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == 'Stopped the QA db.'
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler._run_query')
+    @mock.patch('src.utils.boto3.client', autospec=True)
+    def test_stop_observations_test_db_stop_quiet(self, mock_boto, mock_rds):
+        mock_client = mock.Mock()
+        mock_boto.return_value = mock_client
+        mock_rds.return_value = True
+        os.environ['STAGE'] = 'TEST'
+        result = handler.stop_observations_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == 'Stopped the TEST db.'
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
     def test_start_test_db_something_to_start(self, mock_boto):
         mock_client = mock.Mock()

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from unittest import TestCase, mock
 
@@ -71,7 +72,11 @@ class TestHandler(TestCase):
         os.environ['STAGE'] = 'QA'
         result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the QA db: False'
+        day_of_week = datetime.datetime.today().weekday()
+        if day_of_week == 4:
+            assert result['message'] == 'Stopped the QA db: True'
+        else:
+            assert result['message'] == 'Stopped the QA db: Did not stop QA database because today is not Friday'
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3.client', autospec=True)
@@ -133,4 +138,8 @@ class TestHandler(TestCase):
         os.environ['STAGE'] = 'QA'
         result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the QA db: True'
+        day_of_week = datetime.datetime.today().weekday()
+        if day_of_week == 4:
+            assert result['message'] == 'Stopped the QA db: True'
+        else:
+            assert result['message'] == 'Stopped the QA db: Did not stop QA database because today is not Friday'


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Turns the observations test & qa dbs off and on on a schedule.  However, if a peek at the batch_job_execution table indicates any ETLs are in progress, shutdown will be skipped.

Description
-----------

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
