### PR TITLE
IOW-677 Allow AQTS Ecosystem switch to turn off prod on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New repository
 - Add initial version of the stop and start lambdas for nwcapture test and QA db clusters
 - Add initial version of the stop and start lambdas for observations test and QA db instances
-- Add lambda to enable/disable triggers based on db cpu utilization
+- Add lambda to enable/disable triggers based on errorHandler alarm
+- Add (disabled) on/off schedule for PROD so ecosystem switch can be deployed to PROD

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         }
     }
     parameters {
-        choice(choices: ['TEST', 'QA'], description: 'Deploy Stage (i.e. tier)', name: 'DEPLOY_STAGE')
+        choice(choices: ['TEST', 'QA', 'PROD'], description: 'Deploy Stage (i.e. tier)', name: 'DEPLOY_STAGE')
     }
     triggers {
         pollSCM('H/5 * * * *')

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,20 +21,28 @@ provider:
 custom:
   startObservationSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
-    QA: cron(0 14 ? * MON *)
+    QA: cron(0 12 ? * MON *)
+    PROD: cron(0 12 ? * MON *)
   stopObservationSchedules:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
+    PROD: cron(0 23 ? * FRI *)
   startCaptureSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
-    QA: cron(0 14 ? * MON *)
+    QA: cron(0 12 ? * MON *)
+    PROD: cron(0 12 ? * MON *)
   stopCaptureSchedules:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
+    PROD: cron(0 23 ? * FRI *)
   startScheduleEnabled:
     TEST: true
     QA: false
-
+    PROD: false
+  stopScheduleEnabled:
+    TEST: true
+    QA: true
+    PROD: false
 
   exportGitVariables: false
   accountNumber: ${ssm:/iow/aws/accountNumber}
@@ -44,9 +52,7 @@ custom:
   observationsDb:
     connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-${self:provider.stage}~true}
 
-
 functions:
-
   StartObservationsDb:
     handler: src.handler.start_observations_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
@@ -73,7 +79,7 @@ functions:
     events:
       - schedule:
           rate: ${self:custom.stopObservationSchedules.${self:provider.stage}}
-          enabled: true
+          enabled: ${self:custom.stopScheduleEnabled.${self:provider.stage}}
     vpc: ${self:custom.vpc}
 
   StartCaptureDb:
@@ -99,7 +105,7 @@ functions:
     events:
       - schedule:
           rate: ${self:custom.stopCaptureSchedules.${self:provider.stage}}
-          enabled: true
+          enabled: ${self:custom.stopScheduleEnabled.${self:provider.stage}}
     vpc: ${self:custom.vpc}
 
   ControlDbUtilization:


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Add default stop/start schedules for PROD and disable them to prepare for deploying ecosystem switch to prod.  Add Jenkinsfile deploy target as well.

Description
-----------
If no JIRA ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
