### PR TITLE
IOW-677 add production tier for stop/start dbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add initial version of the stop and start lambdas for observations test and QA db instances
 - Add lambda to enable/disable triggers based on errorHandler alarm
 - Add (disabled) on/off schedule for PROD so ecosystem switch can be deployed to PROD
+- Add SNS top for ControlDbUtilization lambda function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New repository
 - Add initial version of the stop and start lambdas for nwcapture test and QA db clusters
 - Add initial version of the stop and start lambdas for observations test and QA db instances
-- Add lambda to enable/disable triggers based on db cpu utilization
+- Add lambda to enable/disable triggers based on errorHandler alarm
+- Add (disabled) on/off schedule for PROD so ecosystem switch can be deployed to PROD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM usgswma/python:3.8
 
+RUN apt-get update
+
 RUN apt-get install --no-install-recommends -y curl git dnsutils
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt-get install -y nodejs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         }
     }
     parameters {
-        choice(choices: ['TEST', 'QA'], description: 'Deploy Stage (i.e. tier)', name: 'DEPLOY_STAGE')
+        choice(choices: ['TEST', 'QA', 'PROD'], description: 'Deploy Stage (i.e. tier)', name: 'DEPLOY_STAGE')
     }
     triggers {
         pollSCM('H/5 * * * *')

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,20 +21,28 @@ provider:
 custom:
   startObservationSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
-    QA: cron(0 14 ? * MON *)
+    QA: cron(0 12 ? * MON *)
+    PROD: cron(0 12 ? * MON *)
   stopObservationSchedules:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
+    PROD: cron(0 23 ? * FRI *)
   startCaptureSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
-    QA: cron(0 14 ? * MON *)
+    QA: cron(0 12 ? * MON *)
+    PROD: cron(0 12 ? * MON *)
   stopCaptureSchedules:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
+    PROD: cron(0 23 ? * FRI *)
   startScheduleEnabled:
     TEST: true
     QA: false
-
+    PROD: false
+  stopScheduleEnabled:
+    TEST: true
+    QA: true
+    PROD: false
 
   exportGitVariables: false
   accountNumber: ${ssm:/iow/aws/accountNumber}
@@ -44,9 +52,7 @@ custom:
   observationsDb:
     connectInfo: ${ssm:/aws/reference/secretsmanager/WQP-EXTERNAL-${self:provider.stage}~true}
 
-
 functions:
-
   StartObservationsDb:
     handler: src.handler.start_observations_db
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
@@ -73,7 +79,7 @@ functions:
     events:
       - schedule:
           rate: ${self:custom.stopObservationSchedules.${self:provider.stage}}
-          enabled: true
+          enabled: ${self:custom.stopScheduleEnabled.${self:provider.stage}}
     vpc: ${self:custom.vpc}
 
   StartCaptureDb:
@@ -99,7 +105,7 @@ functions:
     events:
       - schedule:
           rate: ${self:custom.stopCaptureSchedules.${self:provider.stage}}
-          enabled: true
+          enabled: ${self:custom.stopScheduleEnabled.${self:provider.stage}}
     vpc: ${self:custom.vpc}
 
   ControlDbUtilization:

--- a/serverless.yml
+++ b/serverless.yml
@@ -125,6 +125,32 @@ functions:
               alarmName: ["aqts-capture-error-handler-${self:provider.stage}-error-alarm"]
     vpc: ${self:custom.vpc}
 
+resources:
+  Resources:
+    snsTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: ${self:service}-${self:provider.stage}-topic
+        TopicName: ${self:service}-${self:provider.stage}-topic
+    concurrencyAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${self:provider.stage}-invocation-alarm
+        AlarmDescription: Notify when the db control utilization lambda is invoked
+        Namespace: 'AWS/Lambda'
+        Dimensions:
+          - Name: FunctionName
+            Value:
+              Ref: ControlDbUtilizationLambdaFunction
+        MetricName: ConcurrentExecutions
+        Statistic: Maximum
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Threshold: 1
+        Period: 60
+        EvaluationPeriods: 1
+        AlarmActions:
+          - Ref: snsTopic
+
 plugins:
   - serverless-plugin-git-variables
   - serverless-python-requirements

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,6 +19,10 @@ provider:
     commitIdentifier: ${git:sha1}
 
 custom:
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions
+  # The test database starts at 7 am central and stops at 6 pm central time, Monday through Friday.
+  # The qa database stops at 6 pm central on Fridays
+  # The production database never stops or starts according to a schedule, the lambdas exist only for manual use.
   startObservationSchedules:
     TEST: cron(0 12 ? * MON-FRI *)
     QA: cron(0 12 ? * MON *)
@@ -35,6 +39,8 @@ custom:
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
     PROD: cron(0 23 ? * FRI *)
+  # No scheduling enabled for prod.  For qa, only Friday stops are scheduled.  For test, both stop and
+  # starts are scheduled.
   startScheduleEnabled:
     TEST: true
     QA: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ provider:
     "wma:environment": ${self:provider.stage}
     "wma:taggingVersion": 0.0.1
     "wma:costCenter": TBD
+    "wma:organization": IOW
     commitIdentifier: ${git:sha1}
 
 custom:
@@ -42,11 +43,11 @@ custom:
   # No scheduling enabled for prod.  For qa, only Friday stops are scheduled.  For test, both stop and
   # starts are scheduled.
   startScheduleEnabled:
-    TEST: true
+    TEST: false
     QA: false
     PROD: false
   stopScheduleEnabled:
-    TEST: true
+    TEST: false
     QA: true
     PROD: false
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -111,8 +111,13 @@ def control_db_utilization(event, context):
         logger.info(f"Disabling trigger {TRIGGER[stage]} because error handler is in alarm")
         disable_triggers(TRIGGER[stage])
     elif alarm_state == "OK":
-        logger.info(f"Enabling trigger {TRIGGER[stage]} because error handler is okay")
-        enable_triggers(TRIGGER[stage])
+        """
+        We do NOT want to enable the trigger if the db is not up and running.
+        """
+        active_dbs = describe_db_clusters('stop')
+        if DB[stage] in active_dbs:
+            logger.info(f"Enabling trigger {TRIGGER[stage]} for {DB[stage]} because error handler is okay")
+            enable_triggers(TRIGGER[stage])
 
 
 def run_etl_query(rds=None):

--- a/src/handler.py
+++ b/src/handler.py
@@ -2,17 +2,34 @@ import os
 import boto3
 from src.rds import RDS
 from src.utils import enable_triggers, describe_db_clusters, start_db_cluster, disable_triggers, stop_db_cluster, \
-    purge_queue
+    purge_queue, stop_observations_db_instance
 import logging
 
-TEST_DB = 'nwcapture-test'
-QA_DB = 'nwcapture-qa'
-SQS_TEST = 'aqts-capture-trigger-queue-TEST'
-SQS_QA = 'aqts-capture-trigger-queue-QA'
-TEST_LAMBDA_TRIGGERS = [
-    'aqts-capture-trigger-TEST-aqtsCaptureTrigger', 'aqts-capture-trigger-tmp-TEST-aqtsCaptureTrigger']
-QA_LAMBDA_TRIGGERS = ['aqts-capture-trigger-QA-aqtsCaptureTrigger']
-SQL = "select count(1) from batch_job_execution where status not in ('COMPLETED', 'FAILED')"
+DB = {
+    "TEST": 'nwcapture-test',
+    "QA": 'nwcapture-qa',
+    "PROD": 'nwcapture-prod-external'
+}
+
+OBSERVATIONS_DB = {
+    "TEST": 'observations-test',
+    "QA": 'observations-qa',
+    "PROD": 'observations-prod-external'
+}
+
+SQS = {
+    "TEST": 'aqts-capture-trigger-queue-TEST',
+    "QA": 'aqts-capture-trigger-queue-QA',
+    "PROD": 'aqts-capture-trigger-queue-PROD-EXTERNAL'
+}
+
+TRIGGER = {
+    "TEST": ['aqts-capture-trigger-TEST-aqtsCaptureTrigger'],
+    "QA": ['aqts-capture-trigger-QA-aqtsCaptureTrigger'],
+    "PROD": ['aqts-capture-trigger-PROD-EXTERNAL-aqtsCaptureTrigger']
+}
+
+OBSERVATIONS_ETL_IN_PROGRESS_SQL = "select count(1) from batch_job_execution where status not in ('COMPLETED', 'FAILED')"
 
 log_level = os.getenv('LOG_LEVEL', logging.ERROR)
 logger = logging.getLogger(__name__)
@@ -21,32 +38,99 @@ logger.setLevel(log_level)
 STAGE = os.getenv('STAGE')
 
 cloudwatch_client = boto3.client('cloudwatch', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
+rds_client = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
 
 
 def start_capture_db(event, context):
-    if os.getenv('STAGE') == 'TEST':
-        started = _start_db(TEST_DB, TEST_LAMBDA_TRIGGERS, SQS_TEST)
-    elif os.getenv('STAGE') == 'QA':
-        started = _start_db(QA_DB, QA_LAMBDA_TRIGGERS, SQS_QA)
+    stage = os.getenv('STAGE')
+    if stage in ["TEST", "QA", "PROD"]:
+        started = _start_db(DB[stage], TRIGGER[stage], SQS[stage])
     else:
         raise Exception(f"stage not recognized {os.getenv('STAGE')}")
     return {
         'statusCode': 200,
-        'message': f"Started the {os.getenv('STAGE')} db: {started}"
+        'message': f"Started the {stage} db: {started}"
     }
 
 
 def stop_capture_db(event, context):
-    if os.getenv('STAGE') == 'TEST':
-        stopped = _stop_db(TEST_DB, TEST_LAMBDA_TRIGGERS)
-    elif os.getenv('STAGE') == 'QA':
-        stopped = _stop_db(QA_DB, QA_LAMBDA_TRIGGERS)
+    stage = os.getenv('STAGE')
+    if stage in ["TEST", "QA", "PROD"]:
+        stopped = _stop_db(DB[stage], TRIGGER[stage])
     else:
         raise Exception(f"stage not recognized {os.getenv('STAGE')}")
     return {
         'statusCode': 200,
         'message': f"Stopped the {os.getenv('STAGE')} db: {stopped}"
     }
+
+
+def stop_observations_db(event, context):
+    stage = os.getenv('STAGE')
+    if stage not in ('TEST', 'QA', 'PROD'):
+        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
+    should_stop = _run_query()
+    if not should_stop:
+        return {
+            'statusCode': 200,
+            'message': f"Could not stop the {stage} observations db. It was busy."
+        }
+    stop_observations_db_instance(OBSERVATIONS_DB[stage])
+    return {
+        'statusCode': 200,
+        'message': f"Stopped the {os.getenv('STAGE')} observations db."
+    }
+
+
+def start_observations_db(event, context):
+    stage = os.getenv('STAGE')
+    if stage not in ('TEST', 'QA', 'PROD'):
+        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
+
+    rds_client.start_db_instance(DBInstanceIdentifier=OBSERVATIONS_DB[stage])
+    return {
+        'statusCode': 200,
+        'message': f"Started the {stage} observations db."
+    }
+
+
+def control_db_utilization(event, context):
+    """
+    Right now we are only listening for the error handler alarm, because it
+    is the last alarm to get triggered when we are going into a death spiral.
+    :param event:
+    :param context:
+    :return:
+    """
+    logger.info(event)
+    alarm_state = event["detail"]["state"]["value"]
+    stage = os.getenv('STAGE')
+    if stage not in ('TEST', 'QA', 'PROD'):
+        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
+
+    if alarm_state == "ALARM":
+        logger.info(f"Disabling trigger {TRIGGER[stage]} because error handler is in alarm")
+        disable_triggers(TRIGGER[stage])
+    elif alarm_state == "OK":
+        logger.info(f"Enabling trigger {TRIGGER[stage]} because error handler is okay")
+        enable_triggers(TRIGGER[stage])
+
+
+def _run_query():
+    """
+    If we look in the batch_job_executions table and something is in a state other than COMPLETED or FAILED,
+    assume an ETL is in progress and don't shut the db down.
+    """
+    rds = RDS()
+    result = rds.execute_sql(OBSERVATIONS_ETL_IN_PROGRESS_SQL)
+    if result[0] > 0:
+        logger.debug(f"Cannot shutdown down observations db because {result[0]} processes are running")
+        return False
+    elif result[0] == 0:
+        logger.debug("Shutting down observations db because no processes are running")
+        return True
+    else:
+        raise Exception(f"something wrong with db result {result}")
 
 
 def _start_db(db, triggers, queue_name):
@@ -70,64 +154,3 @@ def _stop_db(db, triggers):
             stop_db_cluster(db)
             stopped = True
     return stopped
-
-
-def stop_observations_db(event, context):
-    if os.getenv('STAGE') != 'TEST' and os.getenv('STAGE') != 'QA':
-        raise Exception(f"stage not recognized {os.getenv('STAGE')}")
-    should_stop = _run_query()
-    if not should_stop:
-        return {
-            'statusCode': 200,
-            'message': f"Could not stop the {os.getenv('STAGE')} observations db. It was busy."
-        }
-    if os.getenv('STAGE') == 'TEST':
-        logger.debug("trying to stop test database")
-        boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observations-test')
-    else:
-        logger.debug("trying to stop qa database")
-        boto3.client('rds').stop_db_instance(DBInstanceIdentifier='observations-qa')
-    return {
-        'statusCode': 200,
-        'message': f"Stopped the {os.getenv('STAGE')} db."
-    }
-
-
-def start_observations_db(event, context):
-    if os.getenv('STAGE') == 'TEST':
-        boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-test')
-    elif os.getenv('STAGE') == 'QA':
-        boto3.client('rds').start_db_instance(DBInstanceIdentifier='observations-qa')
-
-
-def control_db_utilization(event, context):
-    """
-    Right now we are only listening for the error handler alarm, because it
-    is the last alarm to get triggered when we are going into a death spiral.
-    :param event:
-    :param context:
-    :return:
-    """
-    logger.info(event)
-    alarm_state = event["detail"]["state"]["value"]
-    if (STAGE == "QA"):
-        triggers = QA_LAMBDA_TRIGGERS
-    else:
-        triggers = QA_LAMBDA_TRIGGERS
-    if alarm_state == "ALARM":
-        disable_triggers(triggers)
-    else:
-        enable_triggers(triggers)
-
-
-def _run_query():
-    rds = RDS()
-    result = rds.execute_sql(SQL)
-    if result[0] > 0:
-        logger.debug(f"Cannot shutdown down observations test db because {result[0]} processes are running")
-        return False
-    elif result[0] == 0:
-        logger.debug("Shutting down observations test db because no processes are running")
-        return True
-    else:
-        raise Exception(f"something wrong with db result {result}")

--- a/src/handler.py
+++ b/src/handler.py
@@ -19,9 +19,9 @@ OBSERVATIONS_DB = {
 }
 
 SQS = {
-    "TEST": 'aqts-capture-trigger-queue-TEST',
-    "QA": 'aqts-capture-trigger-queue-QA',
-    "PROD": 'aqts-capture-trigger-queue-PROD-EXTERNAL'
+    "TEST": ['aqts-capture-trigger-queue-TEST', 'aqts-capture-error-queue-TEST'],
+    "QA": ['aqts-capture-trigger-queue-QA', 'aqts-capture-error-queue-QA'],
+    "PROD": ['aqts-capture-trigger-queue-PROD-EXTERNAL']
 }
 
 TRIGGER = {

--- a/src/rds.py
+++ b/src/rds.py
@@ -55,10 +55,11 @@ class RDS:
             logger.debug(f'Error closing connection objection: {repr(e)}', exc_info=True)
             raise RuntimeError
 
-    def execute_sql(self, sql):
+    def execute_sql(self, sql, params):
         try:
-            self.cursor.execute(sql)
+            self.cursor.execute(sql, params)
             return self.cursor.fetchone()
         except (OperationalError, DataError, IntegrityError) as e:
             logger.debug(f'Error during SQL execution: {repr(e)}', exc_info=True)
             self.conn.rollback()
+

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,8 +10,8 @@ my_lambda = boto3.client('lambda', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2
 
 
 def describe_db_clusters(action):
-    my_rds = boto3.client('rds', os.environ['AWS_DEPLOYMENT_REGION'])
     # Get all the instances
+    my_rds = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
     response = my_rds.describe_db_clusters()
     all_dbs = response['DBClusters']
     if action == "start":
@@ -26,7 +26,7 @@ def describe_db_clusters(action):
 
 
 def start_db_cluster(cluster_identifier):
-    my_rds = boto3.client('rds', os.environ['AWS_DEPLOYMENT_REGION'])
+    my_rds = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
     my_rds.start_db_cluster(
         DBClusterIdentifier=cluster_identifier
     )
@@ -34,11 +34,16 @@ def start_db_cluster(cluster_identifier):
 
 
 def stop_db_cluster(cluster_identifier):
-    my_rds = boto3.client('rds', os.environ['AWS_DEPLOYMENT_REGION'])
+    my_rds = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
     my_rds.stop_db_cluster(
         DBClusterIdentifier=cluster_identifier
     )
     return True
+
+
+def stop_observations_db_instance(instance_identifier):
+    my_rds = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
+    my_rds.stop_db_instance(DBClusterIdentifier=instance_identifier)
 
 
 def purge_queue(queue_name):

--- a/src/utils.py
+++ b/src/utils.py
@@ -57,10 +57,12 @@ def disable_triggers(function_names):
     for function_name in function_names:
         response = my_lambda.list_event_source_mappings(FunctionName=function_name)
         for item in response['EventSourceMappings']:
-            my_lambda.update_event_source_mapping(UUID=item['UUID'], Enabled=False)
-            returned = my_lambda.get_event_source_mapping(UUID=item['UUID'])
-            return_value = True
-            logger.debug(f"Trigger should be disabled.  function name: {function_name} item: {returned}")
+            response = my_lambda.get_event_source_mapping(UUID=item['UUID'])
+            if response['State'] in ('Enabled', 'Enabling', 'Updating', 'Creating'):
+                my_lambda.update_event_source_mapping(UUID=item['UUID'], Enabled=False)
+                response = my_lambda.get_event_source_mapping(UUID=item['UUID'])
+                return_value = True
+                logger.info(f"Trigger should be disabled.  function name: {function_name} item: {response}")
     return return_value
 
 
@@ -70,8 +72,11 @@ def enable_triggers(function_names):
     for function_name in function_names:
         response = my_lambda.list_event_source_mappings(FunctionName=function_name)
         for item in response['EventSourceMappings']:
-            my_lambda.update_event_source_mapping(UUID=item['UUID'], Enabled=True)
-            returned = my_lambda.get_event_source_mapping(UUID=item['UUID'])
-            logger.debug(f"Trigger should be enabled.  function name: {function_name} item: {returned}")
-            return_value = True
+            response = my_lambda.get_event_source_mapping(UUID=item['UUID'])
+            print(response)
+            if response['State'] in ('Disabled', 'Disabling', 'Updating', 'Creating'):
+                my_lambda.update_event_source_mapping(UUID=item['UUID'], Enabled=True)
+                response = my_lambda.get_event_source_mapping(UUID=item['UUID'])
+                logger.info(f"Trigger should be enabled.  function name: {function_name} item: {response}")
+                return_value = True
     return return_value

--- a/src/utils.py
+++ b/src/utils.py
@@ -52,7 +52,6 @@ def purge_queue(queue_name):
 
 def disable_triggers(function_names):
     my_lambda = boto3.client('lambda', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
-    logger.debug("trying to disable triggers")
     return_value = False
     for function_name in function_names:
         response = my_lambda.list_event_source_mappings(FunctionName=function_name)
@@ -66,7 +65,6 @@ def disable_triggers(function_names):
 
 def enable_triggers(function_names):
     my_lambda = boto3.client('lambda', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
-    logger.debug(f"trying to enable triggers for function names= {function_names}")
     return_value = False
     for function_name in function_names:
         response = my_lambda.list_event_source_mappings(FunctionName=function_name)

--- a/src/utils.py
+++ b/src/utils.py
@@ -44,10 +44,11 @@ def stop_observations_db_instance(instance_identifier):
     my_rds.stop_db_instance(DBClusterIdentifier=instance_identifier)
 
 
-def purge_queue(queue_name):
-    sqs = boto3.client('sqs', os.getenv('AWS_DEPLOYMENT_REGION'))
-    queue_info = sqs.get_queue_url(QueueName=queue_name)
-    sqs.purge_queue(QueueUrl=queue_info['QueueUrl'])
+def purge_queue(queue_names):
+    for queue_name in queue_names:
+        sqs = boto3.client('sqs', os.getenv('AWS_DEPLOYMENT_REGION'))
+        queue_info = sqs.get_queue_url(QueueName=queue_name)
+        sqs.purge_queue(QueueUrl=queue_info['QueueUrl'])
 
 
 def disable_triggers(function_names):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -2,7 +2,7 @@ import os
 from unittest import TestCase, mock
 
 from src import handler
-from src.handler import TRIGGER
+from src.handler import TRIGGER, STAGES, DB
 
 
 class TestHandler(TestCase):
@@ -45,20 +45,11 @@ class TestHandler(TestCase):
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3', autospec=True)
     def test_start_capture_db_nothing_to_start(self, mock_boto):
-        os.environ['STAGE'] = 'TEST'
-        result = handler.start_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Started the TEST db: False'
-
-        os.environ['STAGE'] = 'QA'
-        result = handler.start_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Started the QA db: False'
-
-        os.environ['STAGE'] = 'PROD'
-        result = handler.start_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Started the PROD db: False'
+        for stage in STAGES:
+            os.environ['STAGE'] = stage
+            result = handler.start_capture_db(self.initial_event, self.context)
+            assert result['statusCode'] == 200
+            assert result['message'] == f"Started the {stage} db: False"
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
@@ -69,20 +60,12 @@ class TestHandler(TestCase):
     @mock.patch('src.utils.boto3.client', autospec=True)
     def test_stop_capture_db_nothing_to_stop(self, mock_boto, mock_disable_triggers):
         mock_disable_triggers.return_value = True
-        os.environ['STAGE'] = 'TEST'
-        result = handler.stop_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the TEST db: False'
 
-        os.environ['STAGE'] = 'QA'
-        result = handler.stop_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the QA db: False'
-
-        os.environ['STAGE'] = 'PROD'
-        result = handler.stop_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the PROD db: False'
+        for stage in STAGES:
+            os.environ['STAGE'] = stage
+            result = handler.stop_capture_db(self.initial_event, self.context)
+            assert result['statusCode'] == 200
+            assert result['message'] == f"Stopped the {stage} db: False"
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
@@ -96,20 +79,11 @@ class TestHandler(TestCase):
         mock_boto.return_value = mock_client
         mock_rds.return_value = False
 
-        os.environ['STAGE'] = 'TEST'
-        result = handler.stop_observations_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == "Could not stop the TEST observations db. It was busy."
-
-        os.environ['STAGE'] = 'QA'
-        result = handler.stop_observations_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == "Could not stop the QA observations db. It was busy."
-
-        os.environ['STAGE'] = 'PROD'
-        result = handler.stop_observations_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == "Could not stop the PROD observations db. It was busy."
+        for stage in STAGES:
+            os.environ['STAGE'] = stage
+            result = handler.stop_observations_db(self.initial_event, self.context)
+            assert result['statusCode'] == 200
+            assert result['message'] == f"Could not stop the {stage} observations db. It was busy."
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
@@ -126,20 +100,11 @@ class TestHandler(TestCase):
         mock_client = mock.Mock()
         mock_boto.return_value = mock_client
 
-        os.environ['STAGE'] = 'TEST'
-        result = handler.stop_observations_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the TEST observations db.'
-
-        os.environ['STAGE'] = 'QA'
-        result = handler.stop_observations_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the QA observations db.'
-
-        os.environ['STAGE'] = 'PROD'
-        result = handler.stop_observations_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the PROD observations db.'
+        for stage in STAGES:
+            os.environ['STAGE'] = stage
+            result = handler.stop_observations_db(self.initial_event, self.context)
+            assert result['statusCode'] == 200
+            assert result['message'] == f"Stopped the {stage} observations db."
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
@@ -147,10 +112,8 @@ class TestHandler(TestCase):
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.enable_triggers', autospec=True)
-    @mock.patch('src.handler.cloudwatch_client')
-    def test_control_db_utilization_enable_test(self, mock_cloudwatch, mock_enable_triggers):
+    def test_control_db_utilization_enable(self, mock_enable_triggers):
         mock_enable_triggers.return_value = True
-        os.environ['STAGE'] = 'TEST'
         my_alarm = {
             "detail": {
                 "state": {
@@ -158,45 +121,19 @@ class TestHandler(TestCase):
                 }
             }
         }
-        handler.control_db_utilization(my_alarm, self.context)
-        mock_enable_triggers.assert_called_once_with(TRIGGER["TEST"])
+        for stage in STAGES:
+            os.environ['STAGE'] = stage
+            handler.control_db_utilization(my_alarm, self.context)
+            mock_enable_triggers.assert_called_with(TRIGGER[stage])
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.enable_triggers', autospec=True)
-    @mock.patch('src.handler.cloudwatch_client')
-    def test_control_db_utilization_enable_qa(self, mock_cloudwatch, mock_enable_triggers):
-        mock_enable_triggers.return_value = True
-        os.environ['STAGE'] = 'QA'
-        my_alarm = {
-            "detail": {
-                "state": {
-                    "value": "OK",
-                }
-            }
-        }
-        handler.control_db_utilization(my_alarm, self.context)
-        mock_enable_triggers.assert_called_once_with(TRIGGER["QA"])
+        os.environ['STAGE'] = 'UNKNOWN'
+        with self.assertRaises(Exception) as context:
+            handler.control_db_utilization(self.initial_event, self.context)
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.enable_triggers', autospec=True)
-    @mock.patch('src.handler.cloudwatch_client')
-    def test_control_db_utilization_enable_prod(self, mock_cloudwatch, mock_enable_triggers):
-        mock_enable_triggers.return_value = True
-        os.environ['STAGE'] = 'PROD'
-        my_alarm = {
-            "detail": {
-                "state": {
-                    "value": "OK",
-                }
-            }
-        }
-        handler.control_db_utilization(my_alarm, self.context)
-        mock_enable_triggers.assert_called_once_with(TRIGGER["PROD"])
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.disable_triggers', autospec=True)
-    @mock.patch('src.handler.cloudwatch_client')
-    def test_control_db_utilization_disable_test(self, mock_cloudwatch, mock_disable_triggers):
+    def test_control_db_utilization_disable(self, mock_disable_triggers):
         mock_disable_triggers.return_value = True
         my_alarm = {
             "detail": {
@@ -205,41 +142,15 @@ class TestHandler(TestCase):
                 }
             }
         }
-        os.environ['STAGE'] = 'TEST'
-        handler.control_db_utilization(my_alarm, self.context)
-        mock_disable_triggers.assert_called_once_with(TRIGGER['TEST'])
+        for stage in STAGES:
+            os.environ['STAGE'] = stage
+            handler.control_db_utilization(my_alarm, self.context)
+            mock_disable_triggers.assert_called_with(TRIGGER[stage])
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.disable_triggers', autospec=True)
-    @mock.patch('src.handler.cloudwatch_client')
-    def test_control_db_utilization_disable_qa(self, mock_cloudwatch, mock_disable_triggers):
-        mock_disable_triggers.return_value = True
-        my_alarm = {
-            "detail": {
-                "state": {
-                    "value": "ALARM",
-                }
-            }
-        }
-        os.environ['STAGE'] = 'QA'
-        handler.control_db_utilization(my_alarm, self.context)
-        mock_disable_triggers.assert_called_once_with(TRIGGER['QA'])
+        os.environ['STAGE'] = 'UNKNOWN'
+        with self.assertRaises(Exception) as context:
+            handler.control_db_utilization(self.initial_event, self.context)
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.disable_triggers', autospec=True)
-    @mock.patch('src.handler.cloudwatch_client')
-    def test_control_db_utilization_disable_test_prod(self, mock_cloudwatch, mock_disable_triggers):
-        mock_disable_triggers.return_value = True
-        my_alarm = {
-            "detail": {
-                "state": {
-                    "value": "ALARM",
-                }
-            }
-        }
-        os.environ['STAGE'] = 'PROD'
-        handler.control_db_utilization(my_alarm, self.context)
-        mock_disable_triggers.assert_called_once_with(TRIGGER['PROD'])
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.enable_triggers', autospec=True)
@@ -250,35 +161,16 @@ class TestHandler(TestCase):
         mock_boto.return_value = mock_client
         my_mock_db_clusters = self.mock_db_clusters
 
-        my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-test'
-        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_client.start_db_cluster.return_value = {'nwcapture-test'}
-        mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
-        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        os.environ['STAGE'] = 'TEST'
-        result = handler.start_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Started the TEST db: True'
-
-        my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-qa'
-        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_client.start_db_cluster.return_value = {'nwcapture-qa'}
-        mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
-        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        os.environ['STAGE'] = 'QA'
-        result = handler.start_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Started the QA db: True'
-
-        my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-prod-external'
-        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_client.start_db_cluster.return_value = {'nwcapture-prod-external'}
-        mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
-        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        os.environ['STAGE'] = 'PROD'
-        result = handler.start_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Started the PROD db: True'
+        for stage in STAGES:
+            my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = DB[stage]
+            mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+            mock_client.start_db_cluster.return_value = {DB[stage]}
+            mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
+            mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
+            os.environ['STAGE'] = stage
+            result = handler.start_capture_db(self.initial_event, self.context)
+            assert result['statusCode'] == 200
+            assert result['message'] == f"Started the {stage} db: True"
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
@@ -291,34 +183,20 @@ class TestHandler(TestCase):
         mock_disable_triggers.return_value = True
         mock_client = mock.Mock()
         my_mock_db_clusters = self.mock_db_clusters
-        my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-test'
-        my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         mock_boto.return_value = mock_client
 
-        os.environ['STAGE'] = 'TEST'
-        result = handler.stop_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the TEST db: True'
-
-        my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-qa'
-        my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
-        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        os.environ['STAGE'] = 'QA'
-        result = handler.stop_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the QA db: True'
-
-        my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-prod-external'
-        my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
-        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
-        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
-        os.environ['STAGE'] = 'PROD'
-        result = handler.stop_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the PROD db: True'
+        for stage in STAGES:
+            my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = DB[stage]
+            my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
+            mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+            mock_client.start_db_cluster.return_value = {DB[stage]}
+            mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
+            os.environ['STAGE'] = stage
+            result = handler.stop_capture_db(self.initial_event, self.context)
+            assert result['statusCode'] == 200
+            assert result['message'] == f"Stopped the {stage} db: True"
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase, mock
 
 from src import handler
+from src.handler import TRIGGER
 
 
 class TestHandler(TestCase):
@@ -43,106 +44,111 @@ class TestHandler(TestCase):
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.utils.boto3', autospec=True)
-    def test_start_test_db_nothing_to_start(self, mock_boto):
+    def test_start_capture_db_nothing_to_start(self, mock_boto):
         os.environ['STAGE'] = 'TEST'
         result = handler.start_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the TEST db: False'
 
+        os.environ['STAGE'] = 'QA'
+        result = handler.start_capture_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == 'Started the QA db: False'
+
+        os.environ['STAGE'] = 'PROD'
+        result = handler.start_capture_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == 'Started the PROD db: False'
+
+        os.environ['STAGE'] = 'UNKNOWN'
+        with self.assertRaises(Exception) as context:
+            handler.start_capture_db(self.initial_event, self.context)
+
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.disable_triggers', autospec=True)
     @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_test_db_nothing_to_stop(self, mock_boto, mock_disable_triggers):
+    def test_stop_capture_db_nothing_to_stop(self, mock_boto, mock_disable_triggers):
         mock_disable_triggers.return_value = True
         os.environ['STAGE'] = 'TEST'
         result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == 'Stopped the TEST db: False'
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.utils.boto3', autospec=True)
-    def test_start_qa_db_nothing_to_start(self, mock_boto):
-        os.environ['STAGE'] = 'QA'
-        result = handler.start_capture_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Started the QA db: False'
-
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.disable_triggers', autospec=True)
-    @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_qa_db_nothing_to_stop(self, mock_boto, mock_disable_triggers):
-        mock_disable_triggers.return_value = True
         os.environ['STAGE'] = 'QA'
         result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == 'Stopped the QA db: False'
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler._run_query')
-    @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_observations_qa_db_dont_stop_busy(self, mock_boto, mock_rds):
-        mock_client = mock.Mock()
-        mock_boto.return_value = mock_client
-        mock_rds.return_value = False
-        os.environ['STAGE'] = 'QA'
-        result = handler.stop_observations_db(self.initial_event, self.context)
+        os.environ['STAGE'] = 'PROD'
+        result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == "Could not stop the QA observations db. It was busy."
+        assert result['message'] == 'Stopped the PROD db: False'
+
+        os.environ['STAGE'] = 'UNKNOWN'
+        with self.assertRaises(Exception) as context:
+            handler.stop_capture_db(self.initial_event, self.context)
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler._run_query')
     @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_observations_test_db_dont_stop_busy(self, mock_boto, mock_rds):
+    def test_stop_observations_db_dont_stop_busy(self, mock_boto, mock_rds):
         mock_client = mock.Mock()
         mock_boto.return_value = mock_client
         mock_rds.return_value = False
+
         os.environ['STAGE'] = 'TEST'
         result = handler.stop_observations_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == "Could not stop the TEST observations db. It was busy."
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler._run_query')
-    @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_observations_db_unknown_stage(self, mock_boto, mock_rds):
-        mock_client = mock.Mock()
-        mock_boto.return_value = mock_client
-        mock_rds.return_value = False
+        os.environ['STAGE'] = 'QA'
+        result = handler.stop_observations_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == "Could not stop the QA observations db. It was busy."
+
+        os.environ['STAGE'] = 'PROD'
+        result = handler.stop_observations_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == "Could not stop the PROD observations db. It was busy."
+
+        os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
             handler.stop_observations_db(self.initial_event, self.context)
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler.stop_observations_db_instance')
     @mock.patch('src.handler.disable_triggers', autospec=True)
     @mock.patch('src.handler._run_query')
     @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_observations_qa_db_stop_quiet(self, mock_boto, mock_rds, mock_disable_triggers):
+    def test_stop_observations_db_stop_quiet(self, mock_boto, mock_rds, mock_disable_triggers, mock_utils_stop_ob):
         mock_disable_triggers.return_value = True
+        mock_utils_stop_ob.return_value = True
         mock_client = mock.Mock()
         mock_boto.return_value = mock_client
-        mock_rds.return_value = True
-        os.environ['STAGE'] = 'QA'
-        result = handler.stop_observations_db(self.initial_event, self.context)
-        assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the QA db.'
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.disable_triggers', autospec=True)
-    @mock.patch('src.handler._run_query')
-    @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_observations_test_db_stop_quiet(self, mock_boto, mock_rds, mock_disable_triggers):
-        mock_disable_triggers.return_value = True
-        mock_client = mock.Mock()
-        mock_boto.return_value = mock_client
-        mock_rds.return_value = True
         os.environ['STAGE'] = 'TEST'
         result = handler.stop_observations_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
-        assert result['message'] == 'Stopped the TEST db.'
+        assert result['message'] == 'Stopped the TEST observations db.'
+
+        os.environ['STAGE'] = 'QA'
+        result = handler.stop_observations_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == 'Stopped the QA observations db.'
+
+        os.environ['STAGE'] = 'PROD'
+        result = handler.stop_observations_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == 'Stopped the PROD observations db.'
+
+        os.environ['STAGE'] = 'UNKNOWN'
+        with self.assertRaises(Exception) as context:
+            handler.stop_observations_db(self.initial_event, self.context)
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.enable_triggers', autospec=True)
     @mock.patch('src.handler.cloudwatch_client')
-    def test_control_db_utilization_enable(self, mock_cloudwatch, mock_enable_triggers):
+    def test_control_db_utilization_enable_test(self, mock_cloudwatch, mock_enable_triggers):
         mock_enable_triggers.return_value = True
         os.environ['STAGE'] = 'TEST'
         my_alarm = {
@@ -153,14 +159,45 @@ class TestHandler(TestCase):
             }
         }
         handler.control_db_utilization(my_alarm, self.context)
-        mock_enable_triggers.assert_called_once()
+        mock_enable_triggers.assert_called_once_with(TRIGGER["TEST"])
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler.enable_triggers', autospec=True)
+    @mock.patch('src.handler.cloudwatch_client')
+    def test_control_db_utilization_enable_qa(self, mock_cloudwatch, mock_enable_triggers):
+        mock_enable_triggers.return_value = True
+        os.environ['STAGE'] = 'QA'
+        my_alarm = {
+            "detail": {
+                "state": {
+                    "value": "OK",
+                }
+            }
+        }
+        handler.control_db_utilization(my_alarm, self.context)
+        mock_enable_triggers.assert_called_once_with(TRIGGER["QA"])
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler.enable_triggers', autospec=True)
+    @mock.patch('src.handler.cloudwatch_client')
+    def test_control_db_utilization_enable_prod(self, mock_cloudwatch, mock_enable_triggers):
+        mock_enable_triggers.return_value = True
+        os.environ['STAGE'] = 'PROD'
+        my_alarm = {
+            "detail": {
+                "state": {
+                    "value": "OK",
+                }
+            }
+        }
+        handler.control_db_utilization(my_alarm, self.context)
+        mock_enable_triggers.assert_called_once_with(TRIGGER["PROD"])
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.disable_triggers', autospec=True)
     @mock.patch('src.handler.cloudwatch_client')
-    def test_control_db_utilization_disable(self, mock_cloudwatch, mock_disable_triggers):
+    def test_control_db_utilization_disable_test(self, mock_cloudwatch, mock_disable_triggers):
         mock_disable_triggers.return_value = True
-        os.environ['STAGE'] = 'TEST'
         my_alarm = {
             "detail": {
                 "state": {
@@ -168,17 +205,51 @@ class TestHandler(TestCase):
                 }
             }
         }
+        os.environ['STAGE'] = 'TEST'
         handler.control_db_utilization(my_alarm, self.context)
-        mock_disable_triggers.assert_called_once()
+        mock_disable_triggers.assert_called_once_with(TRIGGER['TEST'])
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler.disable_triggers', autospec=True)
+    @mock.patch('src.handler.cloudwatch_client')
+    def test_control_db_utilization_disable_qa(self, mock_cloudwatch, mock_disable_triggers):
+        mock_disable_triggers.return_value = True
+        my_alarm = {
+            "detail": {
+                "state": {
+                    "value": "ALARM",
+                }
+            }
+        }
+        os.environ['STAGE'] = 'QA'
+        handler.control_db_utilization(my_alarm, self.context)
+        mock_disable_triggers.assert_called_once_with(TRIGGER['QA'])
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.handler.disable_triggers', autospec=True)
+    @mock.patch('src.handler.cloudwatch_client')
+    def test_control_db_utilization_disable_test_prod(self, mock_cloudwatch, mock_disable_triggers):
+        mock_disable_triggers.return_value = True
+        my_alarm = {
+            "detail": {
+                "state": {
+                    "value": "ALARM",
+                }
+            }
+        }
+        os.environ['STAGE'] = 'PROD'
+        handler.control_db_utilization(my_alarm, self.context)
+        mock_disable_triggers.assert_called_once_with(TRIGGER['PROD'])
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.enable_triggers', autospec=True)
     @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_start_test_db_something_to_start(self, mock_boto, mock_enable_triggers):
+    def test_start_capture_db_something_to_start(self, mock_boto, mock_enable_triggers):
         mock_enable_triggers.return_value = True
         mock_client = mock.Mock()
         mock_boto.return_value = mock_client
         my_mock_db_clusters = self.mock_db_clusters
+
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-test'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
         mock_client.start_db_cluster.return_value = {'nwcapture-test'}
@@ -186,20 +257,12 @@ class TestHandler(TestCase):
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         os.environ['STAGE'] = 'TEST'
         result = handler.start_capture_db(self.initial_event, self.context)
-
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the TEST db: True'
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.enable_triggers', autospec=True)
-    @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_start_qa_db_something_to_start(self, mock_boto, mock_enable_triggers):
-        mock_enable_triggers.return_value = True
-        mock_client = mock.Mock()
-        mock_boto.return_value = mock_client
-        my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-qa'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+        mock_client.start_db_cluster.return_value = {'nwcapture-qa'}
         mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
         os.environ['STAGE'] = 'QA'
@@ -207,31 +270,38 @@ class TestHandler(TestCase):
         assert result['statusCode'] == 200
         assert result['message'] == 'Started the QA db: True'
 
+        my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-prod-external'
+        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+        mock_client.start_db_cluster.return_value = {'nwcapture-prod-external'}
+        mock_client.get_queue_url.return_value = {'QueueUrl': 'queue'}
+        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        os.environ['STAGE'] = 'PROD'
+        result = handler.start_capture_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == 'Started the PROD db: True'
+
+        os.environ['STAGE'] = 'UNKNOWN'
+        with self.assertRaises(Exception) as context:
+            handler.start_capture_db(self.initial_event, self.context)
+
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.disable_triggers', autospec=True)
     @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_test_db_something_to_stop(self, mock_boto, mock_disable_triggers):
+    def test_stop_capture_db_something_to_stop(self, mock_boto, mock_disable_triggers):
         mock_disable_triggers.return_value = True
         mock_client = mock.Mock()
-        mock_boto.return_value = mock_client
         my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-test'
         my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
         mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        mock_boto.return_value = mock_client
+
         os.environ['STAGE'] = 'TEST'
         result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == 'Stopped the TEST db: True'
 
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.disable_triggers', autospec=True)
-    @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_qa_db_something_to_stop(self, mock_boto, mock_disable_triggers):
-        mock_disable_triggers.return_value = True
-        mock_client = mock.Mock()
-        mock_boto.return_value = mock_client
-        my_mock_db_clusters = self.mock_db_clusters
         my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-qa'
         my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
         mock_client.describe_db_clusters.return_value = my_mock_db_clusters
@@ -240,3 +310,16 @@ class TestHandler(TestCase):
         result = handler.stop_capture_db(self.initial_event, self.context)
         assert result['statusCode'] == 200
         assert result['message'] == 'Stopped the QA db: True'
+
+        my_mock_db_clusters['DBClusters'][0]['DBClusterIdentifier'] = 'nwcapture-prod-external'
+        my_mock_db_clusters['DBClusters'][0]['Status'] = 'available'
+        mock_client.describe_db_clusters.return_value = my_mock_db_clusters
+        mock_client.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        os.environ['STAGE'] = 'PROD'
+        result = handler.stop_capture_db(self.initial_event, self.context)
+        assert result['statusCode'] == 200
+        assert result['message'] == 'Stopped the PROD db: True'
+
+        os.environ['STAGE'] = 'UNKNOWN'
+        with self.assertRaises(Exception) as context:
+            handler.stop_capture_db(self.initial_event, self.context)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -228,7 +228,7 @@ class TestHandler(TestCase):
             handler.start_capture_db(self.initial_event, self.context)
 
     @mock.patch('src.rds.RDS', autospec=True)
-    def testrun_etl_query(self, mock_rds):
+    def test_run_etl_query(self, mock_rds):
         """
         So there are 4 ETLs running
         """

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -73,10 +73,7 @@ class TestHandler(TestCase):
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler._run_query')
-    @mock.patch('src.utils.boto3.client', autospec=True)
-    def test_stop_observations_db_dont_stop_busy(self, mock_boto, mock_rds):
-        mock_client = mock.Mock()
-        mock_boto.return_value = mock_client
+    def test_stop_observations_db_dont_stop_busy(self, mock_rds):
         mock_rds.return_value = False
 
         for stage in STAGES:

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest import TestCase, mock
+
+from src.rds import RDS
+
+
+class TestRDS(TestCase):
+
+    def setUp(self):
+        self.host = 'some-host'
+        self.database = 'some-database'
+        self.user = 'some-user'
+        self.password = 'some-password'
+        self.config = {
+            'rds': {
+                'host': self.host,
+                'database': self.database,
+                'user': self.user,
+                'password': self.password
+            }
+        }
+
+    @mock.patch('src.rds.connect')
+    def test_db_connect(self, mock_connection):
+        mock_connection.return_value.cursor.return_value = mock.Mock()
+        with mock.patch.dict('src.config.CONFIG', self.config):
+            RDS()
+            mock_connection.assert_called_with(
+                host='some-host',
+                database='some-database',
+                user='some-user',
+                password='some-password',
+                connect_timeout=65
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,79 @@
+import os
+from unittest import TestCase, mock
+
+from src import handler
+from src.handler import TRIGGER, STAGES, DB
+from src.utils import enable_triggers, disable_triggers
+
+
+class TestUtils(TestCase):
+    queue_url = 'https://sqs.us-south-10.amazonaws.com/887501/some-queue-name'
+    sns_arn = 'arn:aws:sns:us-south-23:5746521541:fake-notification'
+    region = 'us-south-10'
+    max_retries = 6
+    mock_env_vars = {
+        'AWS_DEPLOYMENT_REGION': region,
+        'MAX_RETRIES': str(max_retries)
+    }
+    mock_db_cluster_identifiers = {'nwcapture-test', 'nwcapture-qa'}
+    mock_db_clusters = {
+        'Marker': 'string',
+        'DBClusters': [
+            {
+                'DBClusterIdentifier': 'string',
+                'Status': 'string',
+            },
+        ]
+    }
+
+    mock_event_source_mapping = {
+        'NextMarker': 'string',
+        'EventSourceMappings': [
+            {
+                'UUID': 'string',
+            },
+        ]
+    }
+
+    def setUp(self):
+        self.initial_execution_arn = 'arn:aws:states:us-south-10:98877654311:blah:a17h83j-p84321'
+        self.state_machine_start_input = {
+            'Record': {'eventVersion': '2.1', 'eventSource': 'aws:s3'}
+        }
+        self.initial_event = {'executionArn': self.initial_execution_arn, 'startInput': self.state_machine_start_input}
+        self.context = {'element': 'lithium'}
+
+    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
+    @mock.patch('src.utils.boto3', autospec=True)
+    def test_start_capture_db_nothing_to_start(self, mock_boto):
+        for stage in STAGES:
+            os.environ['STAGE'] = stage
+            result = handler.start_capture_db(self.initial_event, self.context)
+            assert result['statusCode'] == 200
+            assert result['message'] == f"Started the {stage} db: False"
+
+        os.environ['STAGE'] = 'UNKNOWN'
+        with self.assertRaises(Exception) as context:
+            handler.start_capture_db(self.initial_event, self.context)
+
+    @mock.patch('src.utils.boto3.client', autospec=True)
+    def test_enable_triggers(self, mock_boto):
+        client = mock.Mock()
+        mock_boto.return_value = client
+        client.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        result = enable_triggers(["my_function_name"])
+        assert result is True
+        mock_boto.assert_called_with("lambda", "us-west-2")
+        client.list_event_source_mappings.assert_called_with(FunctionName='my_function_name')
+        client.update_event_source_mapping.assert_called_with(UUID='string', Enabled=True)
+
+    @mock.patch('src.utils.boto3.client', autospec=True)
+    def test_disable_triggers(self, mock_boto):
+        client = mock.Mock()
+        mock_boto.return_value = client
+        client.list_event_source_mappings.return_value = self.mock_event_source_mapping
+        result = disable_triggers(["my_function_name"])
+        assert result is True
+        mock_boto.assert_called_with("lambda", "us-west-2")
+        client.list_event_source_mappings.assert_called_with(FunctionName='my_function_name')
+        client.update_event_source_mapping.assert_called_with(UUID='string', Enabled=False)


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
1. Add production tier for manual stop/start of capture and observations db
2. Refactor so everything works by STAGE
3. Add tests
4. Add an SNS topic for invocation of the ControlDbUtilization lambda function.  Since it works based on CloudWatch alarms, the invocations are not totally obvious, as they are in the case of the cron-based db stops and starts.
5. Also add a check when ControlDbUtilization is going to enable/disable triggers, that the database is actually up and running.

Description
-----------
If no JIRA ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
