### PR TITLE
change max size for capture db to 4x large

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ aqts-capture-ecosystem-switch-deleteCaptureDb-QA
 ## Resizing the nwcapture-qa db
 
 Don't attempt to run resize commands manually.  The current behavior is to increase the size of the db to the 
-maximum of db.r5.8xlarge after five minutes of being at more than 75% cpu utilization (via CloudWatch alarm).
-And to decrease the size of the db after one hour of cpu utilization less than 10% (via a cron job).
+maximum of db.r5.4xlarge after five minutes of being at more than 50% cpu utilization (via high cpu CloudWatch alarm).
+And to decrease the size of the db after 30 minutes of cpu utilization less than 10% (via low cpu CloudWatch alarm.
 
 ## What if I need to prevent automatic shutdown of nwcapture-test for a long running test?
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,7 +6,7 @@ log_level = os.getenv('LOG_LEVEL', logging.ERROR)
 logger = logging.getLogger(__name__)
 logger.setLevel(log_level)
 
-DEFAULT_DB_INSTANCE_CLASS = 'db.r5.8xlarge'
+DEFAULT_DB_INSTANCE_CLASS = 'db.r5.4xlarge'
 
 
 def describe_db_clusters(action):


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Change max six of capture db to db.r5.4xlarge

Description
-----------
Because we are throttling the input in aqts-capture-trigger with a reservedConcurrency of 25, it is possible that a 4xlarge instance of the nwcapture db is big enough.  Try and see.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
