### PR TITLE
lengthen evaluation period for high-cpu alarm because right now it is…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -421,7 +421,7 @@ resources:
         Threshold: 50
         Period: 300
         Unit: Percent
-        EvaluationPeriods: 1
+        EvaluationPeriods: 2
         AlarmActions:
           - Ref: snsTopic
     rdsLowCpuAlarm:


### PR DESCRIPTION
… not stable

Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Change evaluation period for high-cpu alarm from 5 minutes to 10 minutes.

Description
-----------
The low cpu alarm, which is set to a 30 minute evaluation period, seems to be working reliably.  The high-cpu currently has intermittent failures.  The minimum granularity for CloudWatch is 5 minutes, so there may be some boundary failure going on.  Increase the high cpu alarm to 10 minutes to see if that stabilizes it.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
