### PR TITLE
IOW-697 revert dynamic resize of observations db

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ aqts-capture-ecosystem-switch-<STAGE>-executeGrow
 
 1. AWS Console->Event Bridge->Events->Rules->aqts-capture-ecosystem-switch-sw-stoptest->Disable
 2. Remember to enable again when your test is concluded.
+
+## Advanced troubleshooting
+
+If you need to turn the capture database off and on independent of the trigger, you can do so using the
+```troubleshoot``` lambda function.  Provide a payload in one of the following two formats:
+
+```
+{ "action": "start_capture_db"}
+{ "action": "stop_capture_db"}
+```
+
+Note that stopping and starting the database without disabling and re-enabling the trigger is likely to
+lead to an increase in errors reported and in the size of the error queue.  

--- a/README.md
+++ b/README.md
@@ -2,32 +2,82 @@
 [![Build Status](https://travis-ci.org/usgs/aqts-capture-ecosystem-switch.svg?branch=master)](https://travis-ci.org/usgs/aqts-capture-ecosystem-switch)
 [![codecov](https://codecov.io/gh/usgs/aqts-capture-ecosystem-switch/branch/master/graph/badge.svg)](https://codecov.io/gh/usgs/aqts-capture-ecosystem-switch)
 
-AWS Lambda functions designed to turn off resources when not in use.
+AWS Lambda functions designed to minimize RDS costs.
+
 
 ## Stopping and starting the nwcapture dbs
 
-Invoke the relevant lambda function (for example, aqts-capture-ecosystem-switch-QA-StopCaptureDb) using any json payload.
+Invoke the relevant lambda function:
+
+```
+aqts-capture-ecosystem-switch-<STAGE>-startCaptureDb
+aqts-capture-ecosystem-switch-<STAGE>-stopCaptureDb
+```
 
 ## Stopping and starting the observation dbs
 
-Invoke the relevant lambda function, but note that shutdown for the observation db is advice and not a command.  If the
+Invoke the relevant lambda function:
+
+```
+aqts-capture-ecosystem-switch-<STAGE>-startObservationsDb
+aqts-capture-ecosystem-switch-<STAGE>-stopObservationsDb
+```
+
+
+Note that shutdown for the observation db is advice and not a command.  If the
 observation db is running an etl job, it will not shut down.
 
-## Creating the nwcapture-qa db
+## Creating the QA databases
 
-The nwcapture is created when needed.  Invoke the state machine aqts-capture-ecosystem-switch-create-db-QA and be 
-prepared to wait up to two hours.
+The nwcapture-qa database and the observations-qa databases are created when needed.  Invoke one of these state 
+machines:
 
-## Deleting the nwcapture-qa db
+```
+ aqts-capture-ecosystem-switch-create-db-QA 
+ aqts-capture-ecosystem-switch-create-obs-db-QA
+```
 
-When you are finished with the nwcapture-qa db, you should delete it.  Invoke the lambda function 
+Be prepared to wait up to two hours for the database to get up and running.
+
+## Deleting the QA databases
+
+When you are finished with a QA database, you should delete it.  Invoke one of these lambda functions 
+
+```
 aqts-capture-ecosystem-switch-deleteCaptureDb-QA
+aqts-capture-ecosystem-switch-deleteObservationsDb-QA
+```
 
 ## Resizing the nwcapture-qa db
 
-Don't attempt to run resize commands manually.  The current behavior is to increase the size of the db to the 
-maximum of db.r5.4xlarge after five minutes of being at more than 50% cpu utilization (via high cpu CloudWatch alarm).
-And to decrease the size of the db after 30 minutes of cpu utilization less than 10% (via low cpu CloudWatch alarm.
+Don't attempt to run resize commands manually.  There are configurable high-cpu and low-cpu alarms defined in the 
+serverless.yml file which will trigger resizes.  If you absolutely must resize manually, you can pass a fake alarm
+in this format:
+
+```
+{
+    "detail": {
+        "state": {
+            "value": "ALARM"
+        }
+    }
+}
+```
+
+For the observations databases, you would pass this payload to the relevant lambda functions:
+
+```
+aqts-capture-ecosystem-switch-<STAGE>-shrinkObsDb
+aqts-capture-ecosystem-switch-<STAGE>-growObsDb
+```
+
+In the case of the capture db, the situation is more complicated because resizing the database involves disabling
+and enabling the data trigger, so pass the fake alarm to these lambdas
+
+```
+aqts-capture-ecosystem-switch-<STAGE>-executeShrink
+aqts-capture-ecosystem-switch-<STAGE>-executeGrow
+```
 
 ## What if I need to prevent automatic shutdown of nwcapture-test for a long running test?
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -364,13 +364,13 @@ functions:
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       LOG_LEVEL: INFO
       STAGE: ${self:provider.stage}
-    events:
-      - cloudwatchEvent:
-          event:
-            source:
-              - 'aws.cloudwatch'
-            detail:
-              alarmName: [ "aqts-capture-ecosystem-switch-${self:provider.stage}-obs-high-cpu-alarm" ]
+#    events:
+#      - cloudwatchEvent:
+#          event:
+#            source:
+#              - 'aws.cloudwatch'
+#            detail:
+#              alarmName: [ "aqts-capture-ecosystem-switch-${self:provider.stage}-obs-high-cpu-alarm" ]
     vpc: ${self:custom.vpc}
 
 
@@ -616,42 +616,42 @@ resources:
         EvaluationPeriods: 6
         AlarmActions:
           - Ref: snsTopic
-    obsHighCpuAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Properties:
-        AlarmName: ${self:service}-${self:provider.stage}-obs-high-cpu-alarm
-        AlarmDescription: Notify when the observations rds cpu goes over the threshold
-        Namespace: 'AWS/RDS'
-        Dimensions:
-          - Name: DBInstanceIdentifier
-            Value: observations-${self:custom.environments.${self:provider.stage}}
-        MetricName: CPUUtilization
-        Statistic: Average
-        ComparisonOperator: GreaterThanOrEqualToThreshold
-        Threshold: 50
-        Period: 300
-        Unit: Percent
-        EvaluationPeriods: 2
-        AlarmActions:
-          - Ref: snsTopic
-    obsLowCpuAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Properties:
-        AlarmName: ${self:service}-${self:provider.stage}-obs-low-cpu-alarm
-        AlarmDescription: Notify when the observations rds cpu goes under the threshold
-        Namespace: 'AWS/RDS'
-        Dimensions:
-          - Name: DBInstanceIdentifier
-            Value: observations-${self:custom.environments.${self:provider.stage}}
-        MetricName: CPUUtilization
-        Statistic: Average
-        ComparisonOperator: LessThanOrEqualToThreshold
-        Threshold: 10
-        Period: 300
-        Unit: Percent
-        EvaluationPeriods: 6
-        AlarmActions:
-          - Ref: snsTopic
+#    obsHighCpuAlarm:
+#      Type: AWS::CloudWatch::Alarm
+#      Properties:
+#        AlarmName: ${self:service}-${self:provider.stage}-obs-high-cpu-alarm
+#        AlarmDescription: Notify when the observations rds cpu goes over the threshold
+#        Namespace: 'AWS/RDS'
+#        Dimensions:
+#          - Name: DBInstanceIdentifier
+#            Value: observations-${self:custom.environments.${self:provider.stage}}
+#        MetricName: CPUUtilization
+#        Statistic: Average
+#        ComparisonOperator: GreaterThanOrEqualToThreshold
+#        Threshold: 50
+#        Period: 300
+#        Unit: Percent
+#        EvaluationPeriods: 2
+#        AlarmActions:
+#          - Ref: snsTopic
+#    obsLowCpuAlarm:
+#      Type: AWS::CloudWatch::Alarm
+#      Properties:
+#        AlarmName: ${self:service}-${self:provider.stage}-obs-low-cpu-alarm
+#        AlarmDescription: Notify when the observations rds cpu goes under the threshold
+#        Namespace: 'AWS/RDS'
+#        Dimensions:
+#          - Name: DBInstanceIdentifier
+#            Value: observations-${self:custom.environments.${self:provider.stage}}
+#        MetricName: CPUUtilization
+#        Statistic: Average
+#        ComparisonOperator: LessThanOrEqualToThreshold
+#        Threshold: 10
+#        Period: 300
+#        Unit: Percent
+#        EvaluationPeriods: 6
+#        AlarmActions:
+#          - Ref: snsTopic
 
 
 plugins:

--- a/serverless.yml
+++ b/serverless.yml
@@ -562,6 +562,42 @@ resources:
         EvaluationPeriods: 6
         AlarmActions:
           - Ref: snsTopic
+    obsHighCpuAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${self:provider.stage}-obs-high-cpu-alarm
+        AlarmDescription: Notify when the observations rds cpu goes over the threshold
+        Namespace: 'AWS/RDS'
+        Dimensions:
+          - Name: DBInstanceIdentifier
+            Value: observations-${self:custom.environments.${self:provider.stage}}-instance1
+        MetricName: CPUUtilization
+        Statistic: Average
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Threshold: 50
+        Period: 300
+        Unit: Percent
+        EvaluationPeriods: 2
+        AlarmActions:
+          - Ref: snsTopic
+    obsLowCpuAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${self:provider.stage}-obs-low-cpu-alarm
+        AlarmDescription: Notify when the observations rds cpu goes under the threshold
+        Namespace: 'AWS/RDS'
+        Dimensions:
+          - Name: DBInstanceIdentifier
+            Value: nwcapture-${self:custom.environments.${self:provider.stage}}-instance1
+        MetricName: CPUUtilization
+        Statistic: Average
+        ComparisonOperator: LessThanOrEqualToThreshold
+        Threshold: 10
+        Period: 300
+        Unit: Percent
+        EvaluationPeriods: 6
+        AlarmActions:
+          - Ref: snsTopic
 
 
 plugins:

--- a/serverless.yml
+++ b/serverless.yml
@@ -348,13 +348,13 @@ functions:
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       LOG_LEVEL: INFO
       STAGE: ${self:provider.stage}
-    events:
-      - cloudwatchEvent:
-          event:
-            source:
-              - 'aws.cloudwatch'
-            detail:
-              alarmName: [ "aqts-capture-ecosystem-switch-${self:provider.stage}-obs-low-cpu-alarm" ]
+#    events:
+#      - cloudwatchEvent:
+#          event:
+#            source:
+#              - 'aws.cloudwatch'
+#            detail:
+#              alarmName: [ "aqts-capture-ecosystem-switch-${self:provider.stage}-obs-low-cpu-alarm" ]
     vpc: ${self:custom.vpc}
 
   growObsDb:

--- a/serverless.yml
+++ b/serverless.yml
@@ -588,7 +588,7 @@ resources:
         Namespace: 'AWS/RDS'
         Dimensions:
           - Name: DBInstanceIdentifier
-            Value: nwcapture-${self:custom.environments.${self:provider.stage}}-instance1
+            Value: observations-${self:custom.environments.${self:provider.stage}}-instance1
         MetricName: CPUUtilization
         Statistic: Average
         ComparisonOperator: LessThanOrEqualToThreshold

--- a/serverless.yml
+++ b/serverless.yml
@@ -303,6 +303,7 @@ functions:
     handler: src.db_create_handler.create_observation_db
     role: arn:aws:iam::#{AWS::AccountId}:role/csr-Lambda-Role
     environment:
+      LAST_OB_DB_SNAPSHOT: ${self:custom.observationsDb.connectInfo.LAST_OB_DB_SNAPSHOT}
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       CAN_DELETE_DB: ${self:custom.canDeleteDb.${self:provider.stage}}
       STAGE: ${self:provider.stage}
@@ -313,6 +314,8 @@ functions:
     handler: src.db_create_handler.copy_observation_db_snapshot
     role: arn:aws:iam::#{AWS::AccountId}:role/csr-Lambda-Role
     environment:
+      # If we are on the dev tier the snapshots need to be manually copied.  See README
+      DEV_TIER_SNAPSHOT: ''
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       CAN_DELETE_DB: ${self:custom.canDeleteDb.${self:provider.stage}}
       STAGE: ${self:provider.stage}
@@ -366,11 +369,11 @@ functions:
 stepFunctions:
   stateMachines:
     aqtsCreateCaptureDb:
-      loggingConfig:
-        level: ALL
-        includeExecutionData: true
-        destinations:
-          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
+      #loggingConfig:
+      #  level: ALL
+      #  includeExecutionData: true
+      #  destinations:
+      #    - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
       name: aqts-capture-ecosystem-switch-create-capture-db-${self:provider.stage}
       definition:
@@ -417,11 +420,11 @@ stepFunctions:
             End: true
 
     aqtsShrinkCaptureDb:
-      loggingConfig:
-        level: ALL
-        includeExecutionData: true
-        destinations:
-          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
+      #loggingConfig:
+      #  level: ALL
+      #  includeExecutionData: true
+      #  destinations:
+      #    - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
       name: aqts-ecosystem-switch-shrink-capture-db-${self:provider.stage}
       definition:
@@ -452,11 +455,11 @@ stepFunctions:
             End: true
 
     aqtsGrowCaptureDb:
-      loggingConfig:
-        level: ALL
-        includeExecutionData: true
-        destinations:
-          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
+      # loggingConfig:
+      #  level: ALL
+      #  includeExecutionData: true
+      #  destinations:
+      #    - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
       name: aqts-ecosystem-switch-grow-capture-db-${self:provider.stage}
       definition:
@@ -487,11 +490,12 @@ stepFunctions:
             End: true
 
     aqtsCreateObDb:
-      loggingConfig:
-        level: ALL
-        includeExecutionData: true
-        destinations:
-          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
+      #loggingConfig:
+      #  level: ALL
+      #  includeExecutionData: true
+      #  destinations:
+      #    destinations:
+      #      - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
       name: aqts-capture-ecosystem-switch-create-obs-db-${self:provider.stage}
       definition:

--- a/serverless.yml
+++ b/serverless.yml
@@ -141,6 +141,15 @@ functions:
           enabled: ${self:custom.stopCaptureDbScheduleEnabled.${self:provider.stage}}
     vpc: ${self:custom.vpc}
 
+  troubleshoot:
+    handler: src.handler.troubleshoot
+    role: arn:aws:iam::#{AWS::AccountId}:role/csr-Lambda-Role
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      LOG_LEVEL: INFO
+      STAGE: ${self:provider.stage}
+    vpc: ${self:custom.vpc}
+
   ControlDbUtil:
     handler: src.handler.control_db_utilization
     role: arn:aws:iam::#{AWS::AccountId}:role/csr-Lambda-Role

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,7 +35,7 @@ custom:
     PROD-EXTERNAL: prod-external
   canDeleteDb:
     DEV: true
-    TEST: false
+    TEST: true
     QA: true
     PROD-EXTERNAL: false
   startObservationSchedules:

--- a/serverless.yml
+++ b/serverless.yml
@@ -570,7 +570,7 @@ resources:
         Namespace: 'AWS/RDS'
         Dimensions:
           - Name: DBInstanceIdentifier
-            Value: observations-${self:custom.environments.${self:provider.stage}}-instance1
+            Value: observations-${self:custom.environments.${self:provider.stage}}
         MetricName: CPUUtilization
         Statistic: Average
         ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -588,7 +588,7 @@ resources:
         Namespace: 'AWS/RDS'
         Dimensions:
           - Name: DBInstanceIdentifier
-            Value: observations-${self:custom.environments.${self:provider.stage}}-instance1
+            Value: observations-${self:custom.environments.${self:provider.stage}}
         MetricName: CPUUtilization
         Statistic: Average
         ComparisonOperator: LessThanOrEqualToThreshold

--- a/serverless.yml
+++ b/serverless.yml
@@ -370,7 +370,7 @@ stepFunctions:
         level: ALL
         includeExecutionData: true
         destinations:
-          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-test:*
+          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
       name: aqts-capture-ecosystem-switch-create-capture-db-${self:provider.stage}
       definition:
@@ -421,7 +421,7 @@ stepFunctions:
         level: ALL
         includeExecutionData: true
         destinations:
-          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-test:*
+          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
       name: aqts-ecosystem-switch-shrink-capture-db-${self:provider.stage}
       definition:
@@ -456,7 +456,7 @@ stepFunctions:
         level: ALL
         includeExecutionData: true
         destinations:
-          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-test:*
+          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
       name: aqts-ecosystem-switch-grow-capture-db-${self:provider.stage}
       definition:
@@ -491,7 +491,7 @@ stepFunctions:
         level: ALL
         includeExecutionData: true
         destinations:
-          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-test:*
+          - arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:step-functions-${self:custom.environments.${self:provider.stage}}:*
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
       name: aqts-capture-ecosystem-switch-create-obs-db-${self:provider.stage}
       definition:

--- a/serverless.yml
+++ b/serverless.yml
@@ -303,7 +303,6 @@ functions:
     handler: src.db_create_handler.create_observation_db
     role: arn:aws:iam::#{AWS::AccountId}:role/csr-Lambda-Role
     environment:
-      LAST_OB_DB_SNAPSHOT: ${self:custom.observationsDb.connectInfo.LAST_OB_DB_SNAPSHOT}
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       CAN_DELETE_DB: ${self:custom.canDeleteDb.${self:provider.stage}}
       STAGE: ${self:provider.stage}
@@ -315,7 +314,7 @@ functions:
     role: arn:aws:iam::#{AWS::AccountId}:role/csr-Lambda-Role
     environment:
       # If we are on the dev tier the snapshots need to be manually copied.  See README
-      DEV_TIER_SNAPSHOT: ''
+      LAST_OB_DB_SNAPSHOT: ${self:custom.observationsDb.connectInfo.LAST_OB_DB_SNAPSHOT}
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       CAN_DELETE_DB: ${self:custom.canDeleteDb.${self:provider.stage}}
       STAGE: ${self:provider.stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -321,6 +321,40 @@ functions:
       LOG_LEVEL: INFO
     vpc: ${self:custom.vpc}
 
+
+  shrinkObsDb:
+    handler: src.db_resize_handler.shrink_observations_db
+    role: arn:aws:iam::#{AWS::AccountId}:role/csr-Lambda-Role
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      LOG_LEVEL: INFO
+      STAGE: ${self:provider.stage}
+    events:
+      - cloudwatchEvent:
+          event:
+            source:
+              - 'aws.cloudwatch'
+            detail:
+              alarmName: [ "aqts-capture-ecosystem-switch-${self:provider.stage}-obs-low-cpu-alarm" ]
+    vpc: ${self:custom.vpc}
+
+  growObsDb:
+    handler: src.db_resize_handler.grow_observations_db
+    role: arn:aws:iam::#{AWS::AccountId}:role/csr-Lambda-Role
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      LOG_LEVEL: INFO
+      STAGE: ${self:provider.stage}
+    events:
+      - cloudwatchEvent:
+          event:
+            source:
+              - 'aws.cloudwatch'
+            detail:
+              alarmName: [ "aqts-capture-ecosystem-switch-${self:provider.stage}-obs-high-cpu-alarm" ]
+    vpc: ${self:custom.vpc}
+
+
 stepFunctions:
   stateMachines:
     aqtsCreateCaptureDb:

--- a/serverless.yml
+++ b/serverless.yml
@@ -39,36 +39,44 @@ custom:
     QA: true
     PROD-EXTERNAL: false
   startObservationSchedules:
+    DEV: cron(0 12 ? * MON *)
     TEST: cron(0 12 ? * MON-FRI *)
     QA: cron(0 12 ? * MON *)
     PROD-EXTERNAL: cron(0 12 ? * MON *)
   stopObservationSchedules:
+    DEV: cron(0 23 ? * FRI *)
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
     PROD-EXTERNAL: cron(0 23 ? * FRI *)
   startCaptureSchedules:
+    DEV: cron(0 12 ? * MON *)
     TEST: cron(0 12 ? * MON-FRI *)
     QA: cron(0 12 ? * MON *)
     PROD-EXTERNAL: cron(0 12 ? * MON *)
   stopCaptureSchedules:
+    DEV: cron(0 23 ? * FRI *)
     TEST: cron(0 23 ? * MON-FRI *)
     QA: cron(0 23 ? * FRI *)
     PROD-EXTERNAL: cron(0 23 ? * FRI *)
   # No scheduling enabled for prod.  For qa, only Friday stops are scheduled.  For test, both stop and
   # starts are scheduled.
   startCaptureDbScheduleEnabled:
+    DEV: false
     TEST: true
     QA: false
     PROD-EXTERNAL: false
   startObservationDbScheduleEnabled:
+    DEV: false
     TEST: true
     QA: false
     PROD-EXTERNAL: false
   stopCaptureDbScheduleEnabled:
+    DEV: false
     TEST: true
     QA: false
     PROD-EXTERNAL: false
   stopObservationDbScheduleEnabled:
+    DEV: true
     TEST: true
     QA: true
     PROD-EXTERNAL: false

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -5,7 +5,7 @@ import os
 import boto3
 from src.rds import RDS
 from src.utils import enable_lambda_trigger, disable_lambda_trigger, \
-    DEFAULT_DB_INSTANCE_CLASS
+    DEFAULT_DB_INSTANCE_CLASS, CAPTURE_INSTANCE_TAGS, OBSERVATION_INSTANCE_TAGS
 import logging
 
 STAGES = ['TEST', 'QA', 'PROD-EXTERNAL']
@@ -53,6 +53,7 @@ cloudwatch_client = boto3.client('cloudwatch', os.getenv('AWS_DEPLOYMENT_REGION'
 secrets_client = boto3.client('secretsmanager', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
 rds_client = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
 sqs_client = boto3.client('sqs', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
+
 
 
 def _get_date_string(my_datetime):
@@ -128,19 +129,7 @@ def create_db_instance(event, context):
         DBInstanceClass=DEFAULT_DB_INSTANCE_CLASS,
         DBClusterIdentifier=DEFAULT_DB_CLUSTER_IDENTIFIER,
         Engine=ENGINE,
-        Tags=[
-            {'Key': 'Name', 'Value': f"NWISWEB-CAPTURE-RDS-AURORA-{stage.upper()}"},
-            {'Key': 'wma:applicationId', 'Value': 'NWISWEB-CAPTURE'},
-            {'Key': 'wma:contact', 'Value': 'tbd'},
-            {'Key': 'wma:costCenter', 'Value': 'tbd'},
-            {'Key': 'wma:criticality', 'Value': 'tbd'},
-            {'Key': 'wma:environment', 'Value': stage},
-            {'Key': 'wma:operationalHours', 'Value': 'tbd'},
-            {'Key': 'wma:organization', 'Value': 'IOW'},
-            {'Key': 'wma:role', 'Value': 'database'},
-            {'Key': 'wma:system', 'Value': 'NWIS'},
-            {'Key': 'wma:subSystem', 'Value': 'NWISWeb-Capture'},
-            {'Key': 'taggingVersion', 'Value': '0.0.1'}]
+        Tags=CAPTURE_INSTANCE_TAGS
     )
 
 
@@ -156,8 +145,6 @@ def restore_db_cluster(event, context):
     kms_key = str(secret_string['KMS_KEY_ID'])
     subgroup_name = str(secret_string['DB_SUBGROUP_NAME'])
     vpc_security_group_id = str(secret_string['VPC_SECURITY_GROUP_ID'])
-    if not kms_key or not subgroup_name or not vpc_security_group_id:
-        raise Exception(f"Missing db configuration data {secret_string}")
     my_snapshot_identifier = get_snapshot_identifier()
     rds_client.restore_db_cluster_from_snapshot(
         DBClusterIdentifier=DEFAULT_DB_CLUSTER_IDENTIFIER,
@@ -244,20 +231,15 @@ def create_observation_db(event, context):
     kms_key = str(secret_string['KMS_KEY_ID'])
     subgroup_name = str(secret_string['DB_SUBGROUP_NAME'])
     vpc_security_group_id = str(secret_string['VPC_SECURITY_GROUP_ID'])
-
-    if not kms_key or not subgroup_name or not vpc_security_group_id:
-        raise Exception(f"Missing db configuration data {secret_string}")
     my_snapshot_identifier = _get_observation_snapshot_identifier()
     logger.info(f"my snapshot identified {my_snapshot_identifier}")
-    if event is not None:
-        if event.get("db_config") is not None and event['db_config'].get('snapshot_identifier') is not None:
-            my_snapshot_identifier = event['db_config'].get("snapshot_identifier")
 
     """
     We need to use the copied snapshot, not the original, because the copied snapshot
     has the correct kms key.
     """
-    logger.info(f"about to call restore_db_instance_from_db_snapshot subgroup_name {subgroup_name} vpc_id = {vpc_security_group_id}")
+    logger.info(
+        f"about to call restore_db_instance_from_db_snapshot subgroup_name {subgroup_name} vpc_id = {vpc_security_group_id}")
     response = rds_client.restore_db_instance_from_db_snapshot(
         DBInstanceIdentifier=f"observations-{STAGE.lower()}",
         DBSnapshotIdentifier=f"observationSnapshot{STAGE}Temp",
@@ -269,18 +251,7 @@ def create_observation_db(event, context):
         VpcSecurityGroupIds=[
             vpc_security_group_id,
         ],
-        Tags=[
-            {'Key': 'Name', 'Value': f"OBSERVATIONS-RDS-{STAGE}"},
-            {'Key': 'wma:applicationId', 'Value': 'OBSERVATIONS'},
-            {'Key': 'wma:contact', 'Value': 'tbd'},
-            {'Key': 'wma:costCenter', 'Value': 'tbd'},
-            {'Key': 'wma:criticality', 'Value': 'tbd'},
-            {'Key': 'wma:environment', 'Value': f"{STAGE.lower()}"},
-            {'Key': 'wma:operationalHours', 'Value': 'tbd'},
-            {'Key': 'wma:organization', 'Value': 'IOW'},
-            {'Key': 'wma:role', 'Value': 'database'},
-            {'Key': 'taggingVersion', 'Value': '0.0.1'}
-        ]
+        Tags=OBSERVATION_INSTANCE_TAGS
 
     )
     logger.info(f"response is {response}")
@@ -295,18 +266,9 @@ def copy_observation_db_snapshot(event, context):
     )
     secret_string = json.loads(original['SecretString'])
     kms_key = str(secret_string['KMS_KEY_ID'])
-    subgroup_name = str(secret_string['DB_SUBGROUP_NAME'])
-    vpc_security_group_id = str(secret_string['VPC_SECURITY_GROUP_ID'])
-    if not kms_key or not subgroup_name or not vpc_security_group_id:
-        raise Exception(f"Missing db configuration data {secret_string}")
     my_snapshot_identifier = _get_observation_snapshot_identifier()
-    if event is not None:
-        if event.get("db_config") is not None and event['db_config'].get('snapshot_identifier') is not None:
-            my_snapshot_identifier = event['db_config'].get("snapshot_identifier")
 
-    need_to_retry = False
-
-    response = rds_client.copy_db_snapshot(
+    rds_client.copy_db_snapshot(
         SourceDBSnapshotIdentifier=my_snapshot_identifier,
         TargetDBSnapshotIdentifier=f"observationSnapshot{STAGE}Temp",
         KmsKeyId=kms_key

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -245,6 +245,7 @@ def create_observation_db(event, context):
         DBInstanceClass='db.r5.2xlarge',
         Port=5432,
         DBSubnetGroupName=subgroup_name,
+        Iops=0,
         MultiAZ=False,
         Engine='postgres',
         VpcSecurityGroupIds=[

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -238,7 +238,7 @@ def create_observation_db(event, context):
     logger.info(event)
 
     original = secrets_client.get_secret_value(
-        SecretId='WQP-EXTERNAL-QA'
+        SecretId=OBSERVATION_REAL
     )
     secret_string = json.loads(original['SecretString'])
     kms_key = str(secret_string['KMS_KEY_ID'])
@@ -288,7 +288,7 @@ def copy_observation_db_snapshot(event, context):
     logger.info(event)
 
     original = secrets_client.get_secret_value(
-        SecretId='WQP-EXTERNAL-QA'
+        SecretId=OBSERVATION_REAL
     )
     secret_string = json.loads(original['SecretString'])
     kms_key = str(secret_string['KMS_KEY_ID'])

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -55,7 +55,6 @@ rds_client = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2')
 sqs_client = boto3.client('sqs', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
 
 
-
 def _get_date_string(my_datetime):
     month = str(my_datetime.month)
     if len(month) == 1:
@@ -273,6 +272,7 @@ def copy_observation_db_snapshot(event, context):
         TargetDBSnapshotIdentifier=f"observationSnapshot{STAGE}Temp",
         KmsKeyId=kms_key
     )
+
 
 def delete_observation_db(event, context):
     _validate()

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -388,6 +388,10 @@ def modify_observation_passwords(event, context):
 
 
 def _get_observation_snapshot_identifier():
+    # In the dev account we don't have a list of automatic backups
+    # See README
+    if os.getenv('LAST_OB_DB_SNAPSHOT') is not None:
+        return os.getenv('LAST_OB_DB_SNAPSHOT')
     two_days_ago = datetime.datetime.now() - datetime.timedelta(2)
     date_str = _get_date_string(two_days_ago)
     response = rds_client.describe_db_snapshots(

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -274,7 +274,6 @@ def copy_observation_db_snapshot(event, context):
         KmsKeyId=kms_key
     )
 
-
 def delete_observation_db(event, context):
     _validate()
     try:

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -23,7 +23,7 @@ NWCAPTURE_REAL = f"NWCAPTURE-DB-{STAGE}"
 SMALL_DB_SIZE = 'db.r5.xlarge'
 BIG_DB_SIZE = DEFAULT_DB_INSTANCE_CLASS
 BIG_OB_DB_SIZE = 'db.r5.2xlarge'
-SMALL_OB_DB_SIZE = 'db.r5.large'
+SMALL_OB_DB_SIZE = 'db.r5.xlarge'
 
 cloudwatch_client = boto3.client('cloudwatch', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
 rds_client = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -22,7 +22,7 @@ NWCAPTURE_REAL = f"NWCAPTURE-DB-{STAGE}"
 SMALL_DB_SIZE = 'db.r5.xlarge'
 BIG_DB_SIZE = DEFAULT_DB_INSTANCE_CLASS
 BIG_OB_DB_SIZE = 'db.r5.2xlarge'
-SMALL_OB_DB_SIZE = 'db.r5.xlarge'
+SMALL_OB_DB_SIZE = 'db.r5.large'
 
 cloudwatch_client = boto3.client('cloudwatch', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
 rds_client = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -3,7 +3,8 @@ import json
 import os
 
 import boto3
-from src.utils import enable_lambda_trigger, disable_lambda_trigger, DEFAULT_DB_INSTANCE_CLASS
+from src.utils import enable_lambda_trigger, disable_lambda_trigger, DEFAULT_DB_INSTANCE_CLASS, CAPTURE_INSTANCE_TAGS, \
+    OBSERVATION_INSTANCE_TAGS
 import logging
 
 TRIGGER = {
@@ -59,7 +60,8 @@ def shrink_db(event, context):
         response = rds_client.modify_db_instance(
             DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
             DBInstanceClass=SMALL_DB_SIZE,
-            ApplyImmediately=True
+            ApplyImmediately=True,
+            Tags=CAPTURE_INSTANCE_TAGS
         )
         logger.info(f"Shrinking DB, please stand by. {response}")
 
@@ -79,7 +81,8 @@ def grow_db(event, context):
         response = rds_client.modify_db_instance(
             DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
             DBInstanceClass=BIG_DB_SIZE,
-            ApplyImmediately=True
+            ApplyImmediately=True,
+            Tags=CAPTURE_INSTANCE_TAGS
         )
         logger.info(f"Growing the DB, please stand by. {response}")
 
@@ -171,7 +174,8 @@ def shrink_observations_db(event, context):
             response = rds_client.modify_db_instance(
                 DBInstanceIdentifier=ob_id,
                 DBInstanceClass=SMALL_OB_DB_SIZE,
-                ApplyImmediately=True
+                ApplyImmediately=True,
+                Tags=OBSERVATION_INSTANCE_TAGS
             )
             logger.info(f"Shrinking observations DB, please stand by. {response}")
 
@@ -191,7 +195,8 @@ def grow_observations_db(event, context):
             response = rds_client.modify_db_instance(
                 DBInstanceIdentifier=ob_id,
                 DBInstanceClass=BIG_OB_DB_SIZE,
-                ApplyImmediately=True
+                ApplyImmediately=True,
+                Tags=OBSERVATION_INSTANCE_TAGS
             )
             logger.info(f"Growing observations DB, please stand by. {response}")
 
@@ -200,4 +205,3 @@ def _validate_observations_resize():
     if os.environ['STAGE'] in ('DEV', 'TEST', 'QA'):
         return
     raise Exception(f"Cannot resize the observations db on tier {os.environ['STAGE']}")
-

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -157,6 +157,7 @@ def _execute_state_machine(state_machine_arn, invocation_payload, region='us-wes
 
 
 def shrink_observations_db(event, context):
+    _validate_observations_resize()
     alarm_state = event["detail"]["state"]["value"]
     if alarm_state == "ALARM":
         logger.info(event)
@@ -176,6 +177,7 @@ def shrink_observations_db(event, context):
 
 
 def grow_observations_db(event, context):
+    _validate_observations_resize()
     alarm_state = event["detail"]["state"]["value"]
     if alarm_state == "ALARM":
         logger.info(event)
@@ -192,3 +194,10 @@ def grow_observations_db(event, context):
                 ApplyImmediately=True
             )
             logger.info(f"Growing observations DB, please stand by. {response}")
+
+
+def _validate_observations_resize():
+    if os.environ['STAGE'] in ('DEV', 'TEST', 'QA'):
+        return
+    raise Exception(f"Cannot resize the observations db on tier {os.environ['STAGE']}")
+

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -60,8 +60,7 @@ def shrink_db(event, context):
         response = rds_client.modify_db_instance(
             DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
             DBInstanceClass=SMALL_DB_SIZE,
-            ApplyImmediately=True,
-            Tags=CAPTURE_INSTANCE_TAGS
+            ApplyImmediately=True
         )
         logger.info(f"Shrinking DB, please stand by. {response}")
 
@@ -81,8 +80,7 @@ def grow_db(event, context):
         response = rds_client.modify_db_instance(
             DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
             DBInstanceClass=BIG_DB_SIZE,
-            ApplyImmediately=True,
-            Tags=CAPTURE_INSTANCE_TAGS
+            ApplyImmediately=True
         )
         logger.info(f"Growing the DB, please stand by. {response}")
 
@@ -174,8 +172,7 @@ def shrink_observations_db(event, context):
             response = rds_client.modify_db_instance(
                 DBInstanceIdentifier=ob_id,
                 DBInstanceClass=SMALL_OB_DB_SIZE,
-                ApplyImmediately=True,
-                Tags=OBSERVATION_INSTANCE_TAGS
+                ApplyImmediately=True
             )
             logger.info(f"Shrinking observations DB, please stand by. {response}")
 
@@ -195,8 +192,7 @@ def grow_observations_db(event, context):
             response = rds_client.modify_db_instance(
                 DBInstanceIdentifier=ob_id,
                 DBInstanceClass=BIG_OB_DB_SIZE,
-                ApplyImmediately=True,
-                Tags=OBSERVATION_INSTANCE_TAGS
+                ApplyImmediately=True
             )
             logger.info(f"Growing observations DB, please stand by. {response}")
 

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -160,7 +160,7 @@ def shrink_observations_db(event, context):
     alarm_state = event["detail"]["state"]["value"]
     if alarm_state == "ALARM":
         logger.info(event)
-        ob_id = f"observations-{STAGE.lower()}-instance1"
+        ob_id = f"observations-{STAGE.lower()}"
         response = rds_client.describe_db_instances(DBInstanceIdentifier=ob_id)
         db_instance_class = str(response['DBInstances'][0]['DBInstanceClass'])
         if db_instance_class == SMALL_OB_DB_SIZE:
@@ -179,7 +179,7 @@ def grow_observations_db(event, context):
     alarm_state = event["detail"]["state"]["value"]
     if alarm_state == "ALARM":
         logger.info(event)
-        ob_id = f"observations-{STAGE.lower()}-instance1"
+        ob_id = f"observations-{STAGE.lower()}"
         response = rds_client.describe_db_instances(DBInstanceIdentifier=ob_id)
         db_instance_class = str(response['DBInstances'][0]['DBInstanceClass'])
         if db_instance_class == BIG_OB_DB_SIZE:

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -22,7 +22,7 @@ NWCAPTURE_REAL = f"NWCAPTURE-DB-{STAGE}"
 SMALL_DB_SIZE = 'db.r5.xlarge'
 BIG_DB_SIZE = DEFAULT_DB_INSTANCE_CLASS
 BIG_OB_DB_SIZE = 'db.r5.2xlarge'
-SMALL_OB_DB_SIZE = 'db.r5.large'
+SMALL_OB_DB_SIZE = 'db.r5.xlarge'
 
 cloudwatch_client = boto3.client('cloudwatch', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
 rds_client = boto3.client('rds', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))

--- a/src/handler.py
+++ b/src/handler.py
@@ -199,6 +199,25 @@ def _stop_db(db, triggers):
     return stopped
 
 
+def troubleshoot(event, context):
+    if event['action'].lower() == 'start_capture_db':
+        print("action is start_capture_db")
+        cluster_identifiers = describe_db_clusters("start")
+        print(f"we called descripe db cluster {cluster_identifiers}")
+        for cluster_identifier in cluster_identifiers:
+            if cluster_identifier == DB[STAGE]:
+                start_db_cluster(DB[STAGE])
+    elif event['action'].lower() == 'stop_capture_db':
+        print("action is stop_capture_db")
+        cluster_identifiers = describe_db_clusters("stop")
+        for cluster_identifier in cluster_identifiers:
+            if cluster_identifier == DB[STAGE]:
+                stop_db_cluster(DB[STAGE])
+    else:
+        print("raising exception")
+        raise Exception("action must be specified and must be 'start_capture_db' or 'stop_capture_db'")
+
+
 """
 Miscellaneous functions
 """

--- a/src/handler.py
+++ b/src/handler.py
@@ -201,20 +201,16 @@ def _stop_db(db, triggers):
 
 def troubleshoot(event, context):
     if event['action'].lower() == 'start_capture_db':
-        print("action is start_capture_db")
         cluster_identifiers = describe_db_clusters("start")
-        print(f"we called descripe db cluster {cluster_identifiers}")
         for cluster_identifier in cluster_identifiers:
             if cluster_identifier == DB[STAGE]:
                 start_db_cluster(DB[STAGE])
     elif event['action'].lower() == 'stop_capture_db':
-        print("action is stop_capture_db")
         cluster_identifiers = describe_db_clusters("stop")
         for cluster_identifier in cluster_identifiers:
             if cluster_identifier == DB[STAGE]:
                 stop_db_cluster(DB[STAGE])
     else:
-        print("raising exception")
         raise Exception("action must be specified and must be 'start_capture_db' or 'stop_capture_db'")
 
 

--- a/src/tests/test_db_create_handler.py
+++ b/src/tests/test_db_create_handler.py
@@ -365,8 +365,8 @@ class TestDbCreateHandler(TestCase):
         mock_rds.restore_db_instance_from_db_snapshot.assert_called_once_with(
             DBInstanceIdentifier='observations-test',
             DBSnapshotIdentifier=f"observationSnapshotTESTTemp", DBInstanceClass='db.r5.2xlarge',
-            Port=5432, DBSubnetGroupName='subgroup', MultiAZ=False, Engine='postgres', VpcSecurityGroupIds=['vpc_id'],
-            Tags=OBSERVATION_INSTANCE_TAGS
+            Port=5432, DBSubnetGroupName='subgroup', Iops=0, MultiAZ=False, Engine='postgres',
+            VpcSecurityGroupIds=['vpc_id'], Tags=OBSERVATION_INSTANCE_TAGS
         )
 
     @mock.patch('src.db_create_handler.secrets_client')

--- a/src/tests/test_db_resize_handler.py
+++ b/src/tests/test_db_resize_handler.py
@@ -68,8 +68,7 @@ class TestDbResizeHandler(TestCase):
         mock_rds.modify_db_instance.assert_called_once_with(
             DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
             DBInstanceClass=SMALL_DB_SIZE,
-            ApplyImmediately=True,
-            Tags=CAPTURE_INSTANCE_TAGS)
+            ApplyImmediately=True)
 
     @mock.patch('src.db_resize_handler._get_cpu_utilization')
     @mock.patch('src.db_resize_handler.rds_client')
@@ -135,8 +134,7 @@ class TestDbResizeHandler(TestCase):
         mock_rds.modify_db_instance.assert_called_once_with(
             DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
             DBInstanceClass=BIG_DB_SIZE,
-            ApplyImmediately=True,
-            Tags=CAPTURE_INSTANCE_TAGS)
+            ApplyImmediately=True)
 
     @mock.patch('src.db_resize_handler._get_cpu_utilization')
     @mock.patch('src.db_resize_handler.rds_client')
@@ -288,8 +286,7 @@ class TestDbResizeHandler(TestCase):
         mock_rds.modify_db_instance.assert_called_once_with(
             DBInstanceIdentifier='observations-test',
             DBInstanceClass=SMALL_OB_DB_SIZE,
-            ApplyImmediately=True,
-            Tags=OBSERVATION_INSTANCE_TAGS)
+            ApplyImmediately=True)
 
     @mock.patch('src.db_resize_handler.rds_client')
     @mock.patch('src.db_resize_handler.disable_lambda_trigger')
@@ -340,8 +337,7 @@ class TestDbResizeHandler(TestCase):
         mock_rds.modify_db_instance.assert_called_once_with(
             DBInstanceIdentifier='observations-test',
             DBInstanceClass=BIG_OB_DB_SIZE,
-            ApplyImmediately=True,
-            Tags=OBSERVATION_INSTANCE_TAGS)
+            ApplyImmediately=True)
 
     @mock.patch('src.db_resize_handler.rds_client')
     @mock.patch('src.db_resize_handler.disable_lambda_trigger')

--- a/src/tests/test_db_resize_handler.py
+++ b/src/tests/test_db_resize_handler.py
@@ -283,7 +283,7 @@ class TestDbResizeHandler(TestCase):
         mock_rds.describe_db_instances.return_value = {"DBInstances": [{"DBInstanceClass": BIG_OB_DB_SIZE}]}
         db_resize_handler.shrink_observations_db(alarm_event, {})
         mock_rds.modify_db_instance.assert_called_once_with(
-            DBInstanceIdentifier='observations-test-instance1',
+            DBInstanceIdentifier='observations-test',
             DBInstanceClass=SMALL_OB_DB_SIZE,
             ApplyImmediately=True)
 
@@ -334,7 +334,7 @@ class TestDbResizeHandler(TestCase):
         mock_rds.describe_db_instances.return_value = {"DBInstances": [{"DBInstanceClass": SMALL_OB_DB_SIZE}]}
         db_resize_handler.grow_observations_db(alarm_event, {})
         mock_rds.modify_db_instance.assert_called_once_with(
-            DBInstanceIdentifier='observations-test-instance1',
+            DBInstanceIdentifier='observations-test',
             DBInstanceClass=BIG_OB_DB_SIZE,
             ApplyImmediately=True)
 

--- a/src/tests/test_db_resize_handler.py
+++ b/src/tests/test_db_resize_handler.py
@@ -5,6 +5,7 @@ from src import db_resize_handler
 from src.db_resize_handler import SMALL_DB_SIZE, BIG_DB_SIZE, DEFAULT_DB_CLUSTER_IDENTIFIER, BIG_OB_DB_SIZE, \
     SMALL_OB_DB_SIZE
 from src.handler import DEFAULT_DB_INSTANCE_IDENTIFIER
+from src.utils import OBSERVATION_INSTANCE_TAGS, CAPTURE_INSTANCE_TAGS
 
 
 class TestDbResizeHandler(TestCase):
@@ -67,7 +68,8 @@ class TestDbResizeHandler(TestCase):
         mock_rds.modify_db_instance.assert_called_once_with(
             DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
             DBInstanceClass=SMALL_DB_SIZE,
-            ApplyImmediately=True)
+            ApplyImmediately=True,
+            Tags=CAPTURE_INSTANCE_TAGS)
 
     @mock.patch('src.db_resize_handler._get_cpu_utilization')
     @mock.patch('src.db_resize_handler.rds_client')
@@ -133,7 +135,8 @@ class TestDbResizeHandler(TestCase):
         mock_rds.modify_db_instance.assert_called_once_with(
             DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
             DBInstanceClass=BIG_DB_SIZE,
-            ApplyImmediately=True)
+            ApplyImmediately=True,
+            Tags=CAPTURE_INSTANCE_TAGS)
 
     @mock.patch('src.db_resize_handler._get_cpu_utilization')
     @mock.patch('src.db_resize_handler.rds_client')
@@ -285,7 +288,8 @@ class TestDbResizeHandler(TestCase):
         mock_rds.modify_db_instance.assert_called_once_with(
             DBInstanceIdentifier='observations-test',
             DBInstanceClass=SMALL_OB_DB_SIZE,
-            ApplyImmediately=True)
+            ApplyImmediately=True,
+            Tags=OBSERVATION_INSTANCE_TAGS)
 
     @mock.patch('src.db_resize_handler.rds_client')
     @mock.patch('src.db_resize_handler.disable_lambda_trigger')
@@ -336,7 +340,8 @@ class TestDbResizeHandler(TestCase):
         mock_rds.modify_db_instance.assert_called_once_with(
             DBInstanceIdentifier='observations-test',
             DBInstanceClass=BIG_OB_DB_SIZE,
-            ApplyImmediately=True)
+            ApplyImmediately=True,
+            Tags=OBSERVATION_INSTANCE_TAGS)
 
     @mock.patch('src.db_resize_handler.rds_client')
     @mock.patch('src.db_resize_handler.disable_lambda_trigger')

--- a/src/utils.py
+++ b/src/utils.py
@@ -103,7 +103,6 @@ def enable_lambda_trigger(function_names):
         response = my_lambda.list_event_source_mappings(FunctionName=function_name)
         for item in response['EventSourceMappings']:
             response = my_lambda.get_event_source_mapping(UUID=item['UUID'])
-            print(response)
             if response['State'] in ('Disabled', 'Disabling', 'Updating', 'Creating'):
                 my_lambda.update_event_source_mapping(UUID=item['UUID'], Enabled=True)
                 response = my_lambda.get_event_source_mapping(UUID=item['UUID'])

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,6 +8,34 @@ logger.setLevel(log_level)
 
 DEFAULT_DB_INSTANCE_CLASS = 'db.r5.4xlarge'
 
+STAGE = os.getenv('STAGE', 'TEST')
+
+CAPTURE_INSTANCE_TAGS = [
+    {'Key': 'Name', 'Value': f"NWISWEB-CAPTURE-RDS-AURORA-{STAGE}"},
+    {'Key': 'wma:applicationId', 'Value': 'NWISWEB-CAPTURE'},
+    {'Key': 'wma:contact', 'Value': 'tbd'},
+    {'Key': 'wma:costCenter', 'Value': 'tbd'},
+    {'Key': 'wma:criticality', 'Value': 'tbd'},
+    {'Key': 'wma:environment', 'Value': STAGE.lower()},
+    {'Key': 'wma:operationalHours', 'Value': 'tbd'},
+    {'Key': 'wma:organization', 'Value': 'IOW'},
+    {'Key': 'wma:role', 'Value': 'database'},
+    {'Key': 'wma:system', 'Value': 'NWIS'},
+    {'Key': 'wma:subSystem', 'Value': 'NWISWeb-Capture'},
+    {'Key': 'taggingVersion', 'Value': '0.0.1'}]
+
+OBSERVATION_INSTANCE_TAGS = [
+    {'Key': 'Name', 'Value': f"OBSERVATIONS-RDS-{STAGE}"},
+    {'Key': 'wma:applicationId', 'Value': 'OBSERVATIONS'},
+    {'Key': 'wma:contact', 'Value': 'tbd'},
+    {'Key': 'wma:costCenter', 'Value': 'tbd'},
+    {'Key': 'wma:criticality', 'Value': 'tbd'},
+    {'Key': 'wma:environment', 'Value': f"{STAGE.lower()}"},
+    {'Key': 'wma:operationalHours', 'Value': 'tbd'},
+    {'Key': 'wma:organization', 'Value': 'IOW'},
+    {'Key': 'wma:role', 'Value': 'database'},
+    {'Key': 'taggingVersion', 'Value': '0.0.1'}
+]
 
 def describe_db_clusters(action):
     # Get all the instances


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Revert dynamic resize of observations db

Description
-----------
The dynamic resize was implemented, but there were some serious drawbacks:

First, the max size of the database is 2xlarge -- which is not very large.  If we shrink to just large, the db becomes too small to do any useful work.  If we shrink to xlarge, that potentially would be okay but the cost savings would be reduced.

More importantly, the observations db and ETLs are not de-coupled, as they are with nwcapture.  With nwcapture we can disable the trigger for incoming data, throw any errors into an error queue, and have confidence that when the db resize completes, work will resume successfully.   This is not the case for the observations db, where ETLs will be disrupted.  And if we limit resizes to when ETLs are not running, that means we are hardly ever resizing (similar to how observations-test hardly ever shuts down at night).  There is always a small ETL in progress it seems.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
