### PR TITLE
circuit breaker should use error-handler concurrency alarm instead of…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -163,7 +163,7 @@ functions:
             source:
               - 'aws.cloudwatch'
             detail:
-              alarmName: ["aqts-capture-error-handler-${self:provider.stage}-error-alarm"]
+              alarmName: ["aqts-capture-error-handler-${self:provider.stage}-concurrency-alarm"]
     vpc: ${self:custom.vpc}
 
   disableTrigger:
@@ -229,7 +229,7 @@ functions:
     events:
       - cloudwatchEvent:
           event:
-            source:aqts-ecosystem-switch-grow-db
+            source:
               - 'aws.cloudwatch'
             detail:
               alarmName: [ "aqts-capture-ecosystem-switch-${self:provider.stage}-high-cpu-alarm" ]


### PR DESCRIPTION
… error alarm

Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Use error handler concurrency alarm (not error alarm) to disable triggers as circuit breaker.

Description
-----------
The error handler error alarm actually flags errors occurring in the error handler and is not a good measure of the system getting overloaded.  The concurrency alarm is, so switch to using this for the last-ditch circuit breaker.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
