### PR TITLE
fix circuit breaker so it re-enables when alarm is over

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -144,9 +144,10 @@ def control_db_utilization(event, context):
     if alarm_state == "ALARM":
         logger.info(f"Disabling trigger {TRIGGER[stage]} because error handler is in alarm")
         disable_lambda_trigger(TRIGGER[stage])
-    elif alarm_state == "OK":
+    else:
         """
-        We do NOT want to enable the trigger if the db is not up and running.
+        If we are not in a state of alarm (i.e. OK or INSUFFICIENT_DATA) then it is okay
+        to enable the trigger if the db is up and running (status == available)
         """
         active_dbs = describe_db_clusters('stop')
         if DB[stage] in active_dbs:


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
We observed that after changes to the alarm the circuit breaker relies on, it disabled the trigger and never re-enabled it.  This is because the new alarm doesn't transition from ALARM to OK, but instead from ALARM to INSUFFICIENT_DATA.   Change the circuit breaker to handle the INSUFFICIENT_DATA case.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
