### PR TITLE
Fix circuit breaker -- make explicit calls to the lambdas enableTrigger and disableTrigger

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -144,9 +144,10 @@ def control_db_utilization(event, context):
     if alarm_state == "ALARM":
         logger.info(f"Disabling trigger {TRIGGER[stage]} because error handler is in alarm")
         disable_lambda_trigger(TRIGGER[stage])
-    elif alarm_state == "OK":
+    else:
         """
-        We do NOT want to enable the trigger if the db is not up and running.
+        If we are not in a state of alarm (i.e. OK or INSUFFICIENT_DATA) then it is okay
+        to enable the trigger if the db is up and running (status == available)
         """
         active_dbs = describe_db_clusters('stop')
         if DB[stage] in active_dbs:

--- a/src/tests/test_handler.py
+++ b/src/tests/test_handler.py
@@ -132,7 +132,7 @@ class TestHandler(TestCase):
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.describe_db_clusters')
-    @mock.patch('src.handler.enable_lambda_trigger', autospec=True)
+    @mock.patch('src.handler.enable_trigger', autospec=True)
     def test_control_db_utilization_enable_lambda_trigger_when_db_on(self, mock_enable_lambda_trigger,
                                                                      mock_describe_db_clusters):
         mock_enable_lambda_trigger.return_value = True
@@ -147,7 +147,7 @@ class TestHandler(TestCase):
             os.environ['STAGE'] = stage
             mock_describe_db_clusters.return_value = DB[stage]
             handler.control_db_utilization(my_alarm, self.context)
-            mock_enable_lambda_trigger.assert_called_with(TRIGGER[stage])
+            mock_enable_lambda_trigger.assert_called_with(my_alarm, self.context)
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
@@ -155,7 +155,7 @@ class TestHandler(TestCase):
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.describe_db_clusters')
-    @mock.patch('src.handler.enable_lambda_trigger', autospec=True)
+    @mock.patch('src.handler.enable_trigger', autospec=True)
     def test_control_db_utilization_dont_enable_lambda_trigger_when_db_off(self, mock_enable_lambda_trigger,
                                                                            mock_describe_db_clusters):
         mock_enable_lambda_trigger.return_value = True
@@ -168,16 +168,15 @@ class TestHandler(TestCase):
         }
         for stage in STAGES:
             os.environ['STAGE'] = stage
-            mock_describe_db_clusters.return_value = "SomebodyElsesDb"
             handler.control_db_utilization(my_alarm, self.context)
-            mock_enable_lambda_trigger.assert_not_called()
+            mock_enable_lambda_trigger.assert_called_with(my_alarm, self.context)
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
             handler.control_db_utilization(self.initial_event, self.context)
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.disable_lambda_trigger', autospec=True)
+    @mock.patch('src.handler.disable_trigger', autospec=True)
     def test_control_db_utilization_disable(self, mock_disable_lambda_trigger):
         mock_disable_lambda_trigger.return_value = True
         my_alarm = {
@@ -190,7 +189,7 @@ class TestHandler(TestCase):
         for stage in STAGES:
             os.environ['STAGE'] = stage
             handler.control_db_utilization(my_alarm, self.context)
-            mock_disable_lambda_trigger.assert_called_with(TRIGGER[stage])
+            mock_disable_lambda_trigger.assert_called_with(my_alarm, self.context)
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
The circuit breaker was enabling and disabling the trigger by making calls to aws that did not show up in the dashboard.  The calls showed up in the logs -- but only if it occurs to the user to check the circuit breaker log, which requires a lot of mental alertness.  Change it so that the circuit breaker explicitly calls the enableTrigger and disableTrigger lambda functions so that these invocations will show up in the dashboard and someone can say "hey, disableTrigger was called here ... if no one did it manually, it had to be the circuit breaker."

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
