### PR TITLE
IOW-755 Maximize database when circuit breaker ends

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -4,7 +4,7 @@ import os
 
 import boto3
 
-from src.db_resize_handler import disable_trigger, enable_trigger
+from src.db_resize_handler import disable_trigger, enable_trigger, execute_grow_machine
 from src.rds import RDS
 from src.utils import enable_lambda_trigger, describe_db_clusters, start_db_cluster, disable_lambda_trigger, \
     stop_db_cluster, \
@@ -150,9 +150,19 @@ def control_db_utilization(event, context):
         """
         If we are not in a state of alarm (i.e. OK or INSUFFICIENT_DATA) then it is okay
         to enable the trigger if the db is up and running (status == available)
+        
+        However, we know there is a backlog to work through so we need to force the db to maximum size
+        by issuing a fake high-cpu alarm.
         """
-        logger.info(f"Enabling trigger {TRIGGER[stage]} for {DB[stage]} because error handler is okay")
-        enable_trigger(event, context)
+
+        event = {
+            "detail": {
+                "state": {
+                    "value": "ALARM"
+                }
+            }
+        }
+        execute_grow_machine(event, {})
 
 
 def run_etl_query(rds=None):

--- a/src/tests/test_handler.py
+++ b/src/tests/test_handler.py
@@ -132,10 +132,10 @@ class TestHandler(TestCase):
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.describe_db_clusters')
-    @mock.patch('src.handler.enable_trigger', autospec=True)
-    def test_control_db_utilization_enable_lambda_trigger_when_db_on(self, mock_enable_lambda_trigger,
+    @mock.patch('src.handler.execute_grow_machine', autospec=True)
+    def test_control_db_utilization_enable_lambda_trigger_when_db_on(self, mock_execute_grow_machine,
                                                                      mock_describe_db_clusters):
-        mock_enable_lambda_trigger.return_value = True
+        mock_execute_grow_machine.return_value = True
         my_alarm = {
             "detail": {
                 "state": {
@@ -147,7 +147,7 @@ class TestHandler(TestCase):
             os.environ['STAGE'] = stage
             mock_describe_db_clusters.return_value = DB[stage]
             handler.control_db_utilization(my_alarm, self.context)
-            mock_enable_lambda_trigger.assert_called_with(my_alarm, self.context)
+            mock_execute_grow_machine.assert_called_with({'detail': {'state': {'value': 'ALARM'}}}, {})
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
@@ -155,10 +155,10 @@ class TestHandler(TestCase):
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.describe_db_clusters')
-    @mock.patch('src.handler.enable_trigger', autospec=True)
-    def test_control_db_utilization_dont_enable_lambda_trigger_when_db_off(self, mock_enable_lambda_trigger,
+    @mock.patch('src.handler.execute_grow_machine', autospec=True)
+    def test_control_db_utilization_dont_enable_lambda_trigger_when_db_off(self, mock_execute_grow_machine,
                                                                            mock_describe_db_clusters):
-        mock_enable_lambda_trigger.return_value = True
+        mock_execute_grow_machine.return_value = True
         my_alarm = {
             "detail": {
                 "state": {
@@ -169,7 +169,7 @@ class TestHandler(TestCase):
         for stage in STAGES:
             os.environ['STAGE'] = stage
             handler.control_db_utilization(my_alarm, self.context)
-            mock_enable_lambda_trigger.assert_called_with(my_alarm, self.context)
+            mock_execute_grow_machine.assert_called_with({'detail': {'state': {'value': 'ALARM'}}}, {})
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
When the circuit breaker ends, it means the system has calmed down a bit, so cpu utilization may be low.  However, there is likely to be a backlog of work in the error queue and the trigger queue, so we need to force the db to its maximum size regardless of the cpu level.

Description
-----------
Send a fake high cpu alarm to the execute_grow_machine lambda to resize the database to its maximum size.  I personally don't think we should make the decision to have the circuit breaker become a 100% manual restart process just yet.  Forcing the db to max size would have corrected the the problem we observed on the QA run without human intervention (it would not have corrected the problem we observed on the TEST run but that is still under investigation).

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
