### PR TITLE
IOW-770 Do not clear queues when trigger restarts

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -181,7 +181,11 @@ def run_etl_query(rds=None):
 
 
 def _start_db(db, triggers, queue_name):
-    purge_queue(queue_name)
+    """
+    Purging the queue was originally done for expense control on the test and QA tiers in the early days, but now that
+    development is further along, we'd like to see these tiers coping with a more production-like backlog.
+    """
+    # purge_queue(queue_name)
     cluster_identifiers = describe_db_clusters("start")
     started = False
     for cluster_identifier in cluster_identifiers:
@@ -227,6 +231,9 @@ def troubleshoot(event, context):
         response = client.delete_stack(
             StackName=stack,
         )
+    elif event['action'].lower() == 'purge_queues':
+        purge_queue(CAPTURE_TRIGGER_QUEUE)
+        purge_queue(ERROR_QUEUE)
     elif event['action'].lower() == 'create_access_point':
         _make_efs_access_point(event)
     elif event['action'].lower() == 'create_fargate_security_group':

--- a/src/tests/test_handler.py
+++ b/src/tests/test_handler.py
@@ -399,3 +399,15 @@ class TestHandler(TestCase):
         mock_client.create_security_group.assert_called_once_with(
             Description='test security group', GroupName='my group', VpcId='fsa12345'
         )
+
+
+    @mock.patch('src.handler.purge_queue', autospec=True)
+    def test_create_efs_access_point(self, mock_purge):
+
+        handler.troubleshoot(
+            {"action": "purge_queues"},
+            self.context
+        )
+
+        self.assertEqual(mock_purge.purge_queue.call_count, 2)
+


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Stop purging the queue when the database starts up.

Description
-----------
We want the AQTS Capture system to work harder on the TEST tier, so stop purging the queue when the database starts up.  This will come closer to simulating the pressure on the production system.   Maintain the ability to purge the queues during unusual situations by using the all-purpose troubleshoot lambda for that.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
