### PR TITLE
IOW-766 Investigate Provisioned Concurrency for a Subset of State Machine Lambdas

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -71,7 +71,8 @@ custom:
   # starts are scheduled.
   startCaptureDbScheduleEnabled:
     DEV: false
-    TEST: true
+    # TODO
+    TEST: false
     QA: false
     PROD-EXTERNAL: false
   startObservationDbScheduleEnabled:
@@ -81,7 +82,8 @@ custom:
     PROD-EXTERNAL: false
   stopCaptureDbScheduleEnabled:
     DEV: false
-    TEST: true
+    # TODO
+    TEST: false
     QA: false
     PROD-EXTERNAL: false
   stopObservationDbScheduleEnabled:

--- a/serverless.yml
+++ b/serverless.yml
@@ -595,6 +595,11 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: EnableProvisionedConcurrency
+          EnableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [enableProvisionedConcurrency, Arn]
             Next: WaitForModify
           WaitForModify:
             Type: Wait
@@ -652,6 +657,11 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: EnableProvisionedConcurrency
+          EnableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ enableProvisionedConcurrency, Arn ]
             Next: WaitForModify
           WaitForModify:
             Type: Wait
@@ -699,6 +709,11 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: EnableProvisionedConcurrency
+          EnableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ enableProvisionedConcurrency, Arn ]
             Next: WaitForModify
           WaitForModify:
             Type: Wait

--- a/serverless.yml
+++ b/serverless.yml
@@ -385,6 +385,20 @@ functions:
       STAGE: ${self:provider.stage}
       LOG_LEVEL: INFO
 
+
+  listProvisionedConcurrency:
+    handler: src.db_resize_handler.list_provisioned_concurrency
+    role:
+      Fn::Sub:
+        - arn:aws:iam::${accountId}:role/csr-Lambda-Role
+        - accountId:
+            Ref: AWS::AccountId
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
+      LOG_LEVEL: INFO
+
+
   deleteCaptureDb:
     handler: src.db_create_handler.delete_capture_db
     role:

--- a/serverless.yml
+++ b/serverless.yml
@@ -71,8 +71,7 @@ custom:
   # starts are scheduled.
   startCaptureDbScheduleEnabled:
     DEV: false
-    # TODO
-    TEST: false
+    TEST: true
     QA: false
     PROD-EXTERNAL: false
   startObservationDbScheduleEnabled:
@@ -82,8 +81,7 @@ custom:
     PROD-EXTERNAL: false
   stopCaptureDbScheduleEnabled:
     DEV: false
-    # TODO
-    TEST: false
+    TEST: true
     QA: false
     PROD-EXTERNAL: false
   stopObservationDbScheduleEnabled:

--- a/serverless.yml
+++ b/serverless.yml
@@ -157,6 +157,17 @@ functions:
           enabled: ${self:custom.stopObservationDbScheduleEnabled.${self:provider.stage}}
 
   StartCaptureDb:
+    handler: src.handler.start_capture_db
+    role:
+      Fn::Sub:
+        - arn:aws:iam::${accountId}:role/csr-Lambda-Role
+        - accountId:
+            Ref: AWS::AccountId
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
+
+  executeStart:
     handler: src.handler.execute_start_machine
     role:
       Fn::Sub:

--- a/serverless.yml
+++ b/serverless.yml
@@ -359,6 +359,30 @@ functions:
       STAGE: ${self:provider.stage}
       LOG_LEVEL: INFO
 
+  enableProvisionedConcurrency:
+    handler: src.db_resize_handler.enable_provisioned_concurrency
+    role:
+      Fn::Sub:
+        - arn:aws:iam::${accountId}:role/csr-Lambda-Role
+        - accountId:
+            Ref: AWS::AccountId
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
+      LOG_LEVEL: INFO
+
+  disableProvisionedConcurrency:
+    handler: src.db_resize_handler.disable_provisioned_concurrency
+    role:
+      Fn::Sub:
+        - arn:aws:iam::${accountId}:role/csr-Lambda-Role
+        - accountId:
+            Ref: AWS::AccountId
+    environment:
+      AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      STAGE: ${self:provider.stage}
+      LOG_LEVEL: INFO
+
   deleteCaptureDb:
     handler: src.db_create_handler.delete_capture_db
     role:

--- a/serverless.yml
+++ b/serverless.yml
@@ -165,6 +165,7 @@ functions:
             Ref: AWS::AccountId
     environment:
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      START_STATE_MACHINE_ARN: arn:aws:states:${self:provider.region}:#{AWS::AccountId}:stateMachine:aqts-ecosystem-switch-start-capture-db-${self:provider.stage}
       STAGE: ${self:provider.stage}
     events:
       - schedule:
@@ -753,7 +754,7 @@ stepFunctions:
 
     aqtsStartCaptureDb:
       role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
-      name: aqts-ecosystem-switch-start-machine-${self:provider.stage}
+      name: aqts-ecosystem-switch-start-capture-db-${self:provider.stage}
       definition:
         Comment: "AQTS Start Capture Db with Provisioned Concurrency"
         StartAt: EnableProvisionedConcurrency

--- a/serverless.yml
+++ b/serverless.yml
@@ -651,10 +651,6 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
-            Next: WaitForGrow
-          WaitForGrow:
-            Type: Wait
-            Seconds: 600
             Next: EnableProvisionedConcurrency
           EnableProvisionedConcurrency:
             Type: Task

--- a/serverless.yml
+++ b/serverless.yml
@@ -582,11 +582,13 @@ stepFunctions:
           ShrinkDb:
             Type: Task
             Resource:
-              Fn::GetAtt: [shrinkDb, Arn]
-            Next: WaitForShrink
-          WaitForShrink:
-            Type: Wait
-            Seconds: 600
+              Fn::GetAtt: [ shrinkDb, Arn ]
+            Retry:
+              - ErrorEquals:
+                  - States.ALL
+                IntervalSeconds: 120
+                MaxAttempts: 10
+                BackoffRate: 1
             Next: EnableProvisionedConcurrency
           EnableProvisionedConcurrency:
             Type: Task
@@ -601,6 +603,12 @@ stepFunctions:
             Type: Task
             Resource:
               Fn::GetAtt: [enableTrigger, Arn]
+            Retry:
+              - ErrorEquals:
+                  - States.ALL
+                IntervalSeconds: 120
+                MaxAttempts: 10
+                BackoffRate: 1
             Next: WaitForProvisionedConcurrency
           WaitForProvisionedConcurrency:
             Type: Wait
@@ -637,6 +645,12 @@ stepFunctions:
             Type: Task
             Resource:
               Fn::GetAtt: [ growDb, Arn ]
+            Retry:
+              - ErrorEquals:
+                  - States.ALL
+                IntervalSeconds: 120
+                MaxAttempts: 10
+                BackoffRate: 1
             Next: WaitForGrow
           WaitForGrow:
             Type: Wait
@@ -655,6 +669,12 @@ stepFunctions:
             Type: Task
             Resource:
               Fn::GetAtt: [ enableTrigger, Arn ]
+            Retry:
+              - ErrorEquals:
+                  - States.ALL
+                IntervalSeconds: 120
+                MaxAttempts: 10
+                BackoffRate: 1
             Next: WaitForProvisionedConcurrency
           WaitForProvisionedConcurrency:
             Type: Wait

--- a/serverless.yml
+++ b/serverless.yml
@@ -595,6 +595,11 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: EnableProvisionedConcurrency
+          EnableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [enableProvisionedConcurrency, Arn]
             Next: WaitForModify
           WaitForModify:
             Type: Wait
@@ -610,6 +615,15 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: WaitForProvisionedConcurrency
+          WaitForProvisionedConcurrency:
+            Type: Wait
+            Seconds: 600
+            Next: DisableProvisionedConcurrency
+          DisableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [disableProvisionedConcurrency, Arn]
             End: true
 
     aqtsGrowCaptureDb:
@@ -643,6 +657,11 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: EnableProvisionedConcurrency
+          EnableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ enableProvisionedConcurrency, Arn ]
             Next: WaitForModify
           WaitForModify:
             Type: Wait
@@ -658,6 +677,15 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: WaitForProvisionedConcurrency
+          WaitForProvisionedConcurrency:
+            Type: Wait
+            Seconds: 600
+            Next: DisableProvisionedConcurrency
+          DisableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ disableProvisionedConcurrency, Arn ]
             End: true
 
     aqtsRecoverFromCircuitBreaker:
@@ -681,6 +709,11 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: EnableProvisionedConcurrency
+          EnableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ enableProvisionedConcurrency, Arn ]
             Next: WaitForModify
           WaitForModify:
             Type: Wait
@@ -696,6 +729,15 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
+            Next: WaitForProvisionedConcurrency
+          WaitForProvisionedConcurrency:
+            Type: Wait
+            Seconds: 600
+            Next: DisableProvisionedConcurrency
+          DisableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ disableProvisionedConcurrency, Arn ]
             End: true
 
     aqtsCreateObDb:

--- a/serverless.yml
+++ b/serverless.yml
@@ -595,11 +595,6 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
-            Next: EnableProvisionedConcurrency
-          EnableProvisionedConcurrency:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [enableProvisionedConcurrency, Arn]
             Next: WaitForModify
           WaitForModify:
             Type: Wait
@@ -657,11 +652,6 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
-            Next: EnableProvisionedConcurrency
-          EnableProvisionedConcurrency:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [ enableProvisionedConcurrency, Arn ]
             Next: WaitForModify
           WaitForModify:
             Type: Wait
@@ -709,11 +699,6 @@ stepFunctions:
                 IntervalSeconds: 120
                 MaxAttempts: 10
                 BackoffRate: 1
-            Next: EnableProvisionedConcurrency
-          EnableProvisionedConcurrency:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [ enableProvisionedConcurrency, Arn ]
             Next: WaitForModify
           WaitForModify:
             Type: Wait

--- a/serverless.yml
+++ b/serverless.yml
@@ -574,27 +574,19 @@ stepFunctions:
             Type: Task
             Resource:
               Fn::GetAtt: [disableTrigger, Arn]
-            Retry:
-              - ErrorEquals:
-                  - States.ALL
-                IntervalSeconds: 120
-                MaxAttempts: 3
-                BackoffRate: 1
             Next: WaitForDisable
           WaitForDisable:
             Type: Wait
-            Seconds: 120
+            Seconds: 180
             Next: ShrinkDb
           ShrinkDb:
             Type: Task
             Resource:
               Fn::GetAtt: [shrinkDb, Arn]
-            Retry:
-              - ErrorEquals:
-                  - States.ALL
-                IntervalSeconds: 120
-                MaxAttempts: 10
-                BackoffRate: 1
+            Next: WaitForShrink
+          WaitForShrink:
+            Type: Wait
+            Seconds: 600
             Next: EnableProvisionedConcurrency
           EnableProvisionedConcurrency:
             Type: Task
@@ -609,12 +601,6 @@ stepFunctions:
             Type: Task
             Resource:
               Fn::GetAtt: [enableTrigger, Arn]
-            Retry:
-              - ErrorEquals:
-                  - States.ALL
-                IntervalSeconds: 120
-                MaxAttempts: 10
-                BackoffRate: 1
             Next: WaitForProvisionedConcurrency
           WaitForProvisionedConcurrency:
             Type: Wait
@@ -651,12 +637,10 @@ stepFunctions:
             Type: Task
             Resource:
               Fn::GetAtt: [ growDb, Arn ]
-            Retry:
-              - ErrorEquals:
-                  - States.ALL
-                IntervalSeconds: 120
-                MaxAttempts: 10
-                BackoffRate: 1
+            Next: WaitForGrow
+          WaitForGrow:
+            Type: Wait
+            Seconds: 600
             Next: EnableProvisionedConcurrency
           EnableProvisionedConcurrency:
             Type: Task
@@ -671,12 +655,6 @@ stepFunctions:
             Type: Task
             Resource:
               Fn::GetAtt: [ enableTrigger, Arn ]
-            Retry:
-              - ErrorEquals:
-                  - States.ALL
-                IntervalSeconds: 120
-                MaxAttempts: 10
-                BackoffRate: 1
             Next: WaitForProvisionedConcurrency
           WaitForProvisionedConcurrency:
             Type: Wait

--- a/serverless.yml
+++ b/serverless.yml
@@ -155,7 +155,7 @@ functions:
           enabled: ${self:custom.stopObservationDbScheduleEnabled.${self:provider.stage}}
 
   StartCaptureDb:
-    handler: src.handler.start_capture_db
+    handler: src.handler.execute_start_machine
     role:
       Fn::Sub:
         - arn:aws:iam::${accountId}:role/csr-Lambda-Role
@@ -739,6 +739,35 @@ stepFunctions:
             Resource:
               Fn::GetAtt: [ disableProvisionedConcurrency, Arn ]
             End: true
+
+
+    aqtsStartCaptureDb:
+      role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
+      name: aqts-ecosystem-switch-start-machine-${self:provider.stage}
+      definition:
+        Comment: "AQTS Start Capture Db with Provisioned Concurrency"
+        StartAt: EnableProvisionedConcurrency
+        States:
+          EnableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ enableProvisionedConcurrency, Arn ]
+            Next: StartDb
+          StartDb:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ StartCaptureDb, Arn ]
+            Next: WaitForDbStartup
+          WaitForDbStartup:
+            Type: Wait
+            Seconds: 900
+            Next: DisableProvisionedConcurrency
+          DisableProvisionedConcurrency:
+            Type: Task
+            Resource:
+              Fn::GetAtt: [ disableProvisionedConcurrency, Arn ]
+            End: true
+
 
     aqtsCreateObDb:
       #loggingConfig:

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -170,15 +170,6 @@ def _is_cluster_available(cluster_id):
         raise Exception(f"DB {DEFAULT_DB_CLUSTER_IDENTIFIER} is not ready yet")
 
 
-def _execute_state_machine(state_machine_arn, invocation_payload, region='us-west-2'):
-    sf = boto3.client('stepfunctions', region_name=region)
-    resp = sf.start_execution(
-        stateMachineArn=state_machine_arn,
-        input=invocation_payload
-    )
-    return resp
-
-
 def shrink_observations_db(event, context):
     _validate_observations_resize()
     alarm_state = event["detail"]["state"]["value"]
@@ -291,3 +282,14 @@ def _validate_observations_resize():
     if os.environ['STAGE'] in ('DEV', 'TEST', 'QA'):
         return
     raise Exception(f"Cannot resize the observations db on tier {os.environ['STAGE']}")
+
+
+
+def _execute_state_machine(state_machine_arn, invocation_payload, region='us-west-2'):
+    sf = boto3.client('stepfunctions', region_name=region)
+    resp = sf.start_execution(
+        stateMachineArn=state_machine_arn,
+        input=invocation_payload
+    )
+    return resp
+

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -99,6 +99,7 @@ def grow_db(event, context):
 
 
 def execute_shrink_machine(event, context):
+    enable_provisioned_concurrency()
     arn = os.environ['SHRINK_STATE_MACHINE_ARN']
     payload = {}
     alarm_state = event["detail"]["state"]["value"]
@@ -109,6 +110,7 @@ def execute_shrink_machine(event, context):
 
 
 def execute_grow_machine(event, context):
+    enable_provisioned_concurrency()
     arn = os.environ['GROW_STATE_MACHINE_ARN']
     payload = {}
     alarm_state = event["detail"]["state"]["value"]
@@ -119,10 +121,10 @@ def execute_grow_machine(event, context):
 
 
 def execute_recover_machine(event, context):
+    enable_provisioned_concurrency()
     arn = os.environ['RECOVER_STATE_MACHINE_ARN']
     payload = {}
     _execute_state_machine(arn, json.dumps(payload))
-
 
 
 def _get_cpu_utilization(db_instance_identifier, period_in_seconds, total_time):

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -222,10 +222,16 @@ def enable_provisioned_concurrency(event, context):
     for function_name in LIST_OF_LAMBDAS:
         response = client.list_versions_by_function(FunctionName=function_name)
         latest_version = _get_function_version(response)
+        """
+        TODO: provisionedConcurrency cannot exceed any reservedConcurrency limit that is set.
+        """
+        concurrent_executions = 10
+        if function_name.endswith("iowCapture") or function_name.endswith("iowCaptureMedium"):
+            concurrent_executions = 5
         response = client.put_provisioned_concurrency_config(
             FunctionName=function_name,
             Qualifier=latest_version,
-            ProvisionedConcurrentExecutions=10
+            ProvisionedConcurrentExecutions=concurrent_executions
         )
         logger.info(f"enabling_provisioned_concurrency:\n {response}")
 

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -205,7 +205,7 @@ def enable_provisioned_concurrency(event, context):
     list_of_functions = [f"aqts-capture-discrete-loader-{STAGE}-loadDiscrete"]
 
     for function_name in list_of_functions:
-        response = client.get_function(FunctionName=function_name)
+        response = client.get_function_configuration(FunctionName=function_name)
         print(response)
         response = client.put_provisioned_concurrency_config(
             FunctionName=function_name,

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -229,7 +229,7 @@ def enable_provisioned_concurrency(event, context):
         """
         concurrent_executions = 10
         logger.info(f"set initial concurrent executions to 10 for {function_name}")
-        response = client.get_function_concurrency(function_name)
+        response = client.get_function_concurrency(FunctionName=function_name)
         logger.info(f"response from get_function_concurrency")
         reserved = response['ReservedConcurrentExecutions']
         logger.info(f"reserved = {reserved} for {function_name}")

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -260,7 +260,7 @@ def list_provisioned_concurrency(event, context):
     all_provisioned = []
     for function_name in LIST_OF_LAMBDAS:
         response = client.list_provisioned_concurrency_configs(FunctionName=function_name)
-        if len(response['ProvisionedConcurrencyConfigs'] > 0):
+        if len(response['ProvisionedConcurrencyConfigs']) > 0:
             all_provisioned.append(f"function: {function_name} {response['ProvisionedConcurrencyConfigs']}")
     logger.info(f"All provisioned concurrency: \n{all_provisioned}")
     return all_provisioned

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -264,6 +264,15 @@ def _get_all_function_versions(response):
     return version_list
 
 
+def list_provisioned_concurrency(event, context):
+    client = boto3.client('lambda', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
+    all_provisioned = []
+    for function_name in LIST_OF_LAMBDAS:
+        response = client.list_provisioned_concurrency_configs(FunctionName=function_name)
+        all_provisioned.append(response)
+    logger.info(f"All provisioned concurrency: \n{all_provisioned}")
+    return all_provisioned
+
 def disable_provisioned_concurrency(event, context):
     client = boto3.client('lambda', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
 

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import datetime
 import json
 import os
@@ -226,8 +228,14 @@ def enable_provisioned_concurrency(event, context):
         TODO: provisionedConcurrency cannot exceed any reservedConcurrency limit that is set.
         """
         concurrent_executions = 10
-        if function_name.endswith("iowCapture") or function_name.endswith("iowCaptureMedium"):
-            concurrent_executions = 5
+        logger.info(f"set initial concurrent executions to 10 for {function_name}")
+        response = client.get_function_concurrency(function_name)
+        logger.info(f"response from get_function_concurrency")
+        reserved = response['ReservedConcurrentExecutions']
+        logger.info(f"reserved = {reserved} for {function_name}")
+        if '0' < reserved < '10':
+            concurrent_executions = reserved
+            logger.info(f"resetting provisioning target to {reserved} for {function_name}")
         response = client.put_provisioned_concurrency_config(
             FunctionName=function_name,
             Qualifier=latest_version,

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -224,16 +224,16 @@ def enable_provisioned_concurrency(event, context):
     for function_name in LIST_OF_LAMBDAS:
         response = client.list_versions_by_function(FunctionName=function_name)
         latest_version = _get_function_version(response)
-        """
-        TODO: provisionedConcurrency cannot exceed any reservedConcurrency limit that is set.
-        """
+       
         concurrent_executions = 10
         logger.info(f"set initial concurrent executions to 10 for {function_name}")
         response = client.get_function_concurrency(FunctionName=function_name)
         logger.info(f"response from get_function_concurrency {response}")
-        reserved = response['ReservedConcurrentExecutions']
+        reserved = response.get('ReservedConcurrentExecutions')
         logger.info(f"reserved = {reserved} for {function_name}")
-        if 0 < reserved < 10:
+        if reserved is None:
+            logger.info(f"reserved was none for {function_name}")
+        elif 0 < reserved < 10:
             concurrent_executions = reserved
             logger.info(f"resetting provisioning target to {reserved} for {function_name}")
         response = client.put_provisioned_concurrency_config(

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -205,7 +205,7 @@ def enable_provisioned_concurrency(event, context):
     list_of_functions = [f"aqts-capture-discrete-loader-{STAGE}-loadDiscrete"]
 
     for function_name in list_of_functions:
-        response = client.get_function_configuration(FunctionName=function_name)
+        response = client.list_versions_by_function(FunctionName=function_name)
         print(response)
         response = client.put_provisioned_concurrency_config(
             FunctionName=function_name,

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -260,7 +260,8 @@ def list_provisioned_concurrency(event, context):
     all_provisioned = []
     for function_name in LIST_OF_LAMBDAS:
         response = client.list_provisioned_concurrency_configs(FunctionName=function_name)
-        all_provisioned.append(response)
+        if len(response['ProvisionedConcurrencyConfigs'] > 0):
+            all_provisioned.append(f"function: {function_name} {response['ProvisionedConcurrencyConfigs']}")
     logger.info(f"All provisioned concurrency: \n{all_provisioned}")
     return all_provisioned
 

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -205,9 +205,10 @@ def enable_provisioned_concurrency(event, context):
     list_of_functions = [f"aqts-capture-discrete-loader-{STAGE}-loadDiscrete"]
 
     for function_name in list_of_functions:
+        #response = client.get_alias()
         response = client.put_provisioned_concurrency_config(
             FunctionName=function_name,
-            Qualifier='LATEST',
+            Qualifier='$LATEST',
             ProvisionedConcurrentExecutions=1
         )
         print(response)
@@ -220,7 +221,7 @@ def disable_provisioned_concurrency(event, context):
     for function_name in list_of_functions:
         response = client.delete_provisioned_concurrency_config(
             FunctionName=function_name,
-            Qualifier='LATEST'
+            Qualifier='$LATEST'
         )
         print(response)
 

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -39,7 +39,7 @@ LIST_OF_LAMBDAS = [
     f"aqts-capture-field-visit-metadata-{STAGE}-preProcess",
     f"aqts-capture-field-visit-transform-{STAGE}-transform",
     f"aqts-capture-pruner-{STAGE}-pruneTimeSeries",
-    f"aqts-capture-raw-load-{STAGE}-iowExtraSmall",
+    f"aqts-capture-raw-load-{STAGE}-iowCaptureExtraSmall",
     f"aqts-capture-raw-load-{STAGE}-iowCapture",
     f"aqts-capture-raw-load-{STAGE}-iowCaptureSmall",
     f"aqts-capture-raw-load-{STAGE}-iowCaptureMedium",

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -99,7 +99,6 @@ def grow_db(event, context):
 
 
 def execute_shrink_machine(event, context):
-    enable_provisioned_concurrency({}, {})
     arn = os.environ['SHRINK_STATE_MACHINE_ARN']
     payload = {}
     alarm_state = event["detail"]["state"]["value"]
@@ -110,7 +109,6 @@ def execute_shrink_machine(event, context):
 
 
 def execute_grow_machine(event, context):
-    enable_provisioned_concurrency({}, {})
     arn = os.environ['GROW_STATE_MACHINE_ARN']
     payload = {}
     alarm_state = event["detail"]["state"]["value"]
@@ -121,10 +119,10 @@ def execute_grow_machine(event, context):
 
 
 def execute_recover_machine(event, context):
-    enable_provisioned_concurrency({}, {})
     arn = os.environ['RECOVER_STATE_MACHINE_ARN']
     payload = {}
     _execute_state_machine(arn, json.dumps(payload))
+
 
 
 def _get_cpu_utilization(db_instance_identifier, period_in_seconds, total_time):

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -222,11 +222,12 @@ def enable_provisioned_concurrency(event, context):
     for function_name in LIST_OF_LAMBDAS:
         response = client.list_versions_by_function(FunctionName=function_name)
         latest_version = _get_function_version(response)
-        client.put_provisioned_concurrency_config(
+        response = client.put_provisioned_concurrency_config(
             FunctionName=function_name,
             Qualifier=latest_version,
             ProvisionedConcurrentExecutions=1
         )
+        logger.info(f"enabling_provisioned_concurrency:\n {response}")
 
 
 def _get_function_version(response):
@@ -249,6 +250,7 @@ def disable_provisioned_concurrency(event, context):
             FunctionName=function_name,
             Qualifier=latest_version
         )
+        logger.info(f"disabling_provisioned_concurrency:\n {response}")
 
 
 def _validate_observations_resize():

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -99,7 +99,7 @@ def grow_db(event, context):
 
 
 def execute_shrink_machine(event, context):
-    enable_provisioned_concurrency()
+    enable_provisioned_concurrency({}, {})
     arn = os.environ['SHRINK_STATE_MACHINE_ARN']
     payload = {}
     alarm_state = event["detail"]["state"]["value"]
@@ -110,7 +110,7 @@ def execute_shrink_machine(event, context):
 
 
 def execute_grow_machine(event, context):
-    enable_provisioned_concurrency()
+    enable_provisioned_concurrency({}, {})
     arn = os.environ['GROW_STATE_MACHINE_ARN']
     payload = {}
     alarm_state = event["detail"]["state"]["value"]
@@ -121,7 +121,7 @@ def execute_grow_machine(event, context):
 
 
 def execute_recover_machine(event, context):
-    enable_provisioned_concurrency()
+    enable_provisioned_concurrency({}, {})
     arn = os.environ['RECOVER_STATE_MACHINE_ARN']
     payload = {}
     _execute_state_machine(arn, json.dumps(payload))

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -216,15 +216,15 @@ def enable_provisioned_concurrency(event, context):
         response = client.list_versions_by_function(FunctionName=function_name)
         latest_version = _get_function_version(response)
 
-        concurrent_executions = 10
-        logger.info(f"set initial concurrent executions to 10 for {function_name}")
+        concurrent_executions = 25
+        logger.info(f"set initial concurrent executions to 25 for {function_name}")
         response = client.get_function_concurrency(FunctionName=function_name)
         logger.info(f"response from get_function_concurrency {response}")
         reserved = response.get('ReservedConcurrentExecutions')
         logger.info(f"reserved = {reserved} for {function_name}")
         if reserved is None:
             logger.info(f"reserved was none for {function_name}")
-        elif 0 < reserved < 10:
+        elif 0 < reserved < 25:
             concurrent_executions = reserved
             logger.info(f"resetting provisioning target to {reserved} for {function_name}")
         response = client.put_provisioned_concurrency_config(

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -230,10 +230,10 @@ def enable_provisioned_concurrency(event, context):
         concurrent_executions = 10
         logger.info(f"set initial concurrent executions to 10 for {function_name}")
         response = client.get_function_concurrency(FunctionName=function_name)
-        logger.info(f"response from get_function_concurrency")
+        logger.info(f"response from get_function_concurrency {response}")
         reserved = response['ReservedConcurrentExecutions']
         logger.info(f"reserved = {reserved} for {function_name}")
-        if '0' < reserved < '10':
+        if 0 < reserved < 10:
             concurrent_executions = reserved
             logger.info(f"resetting provisioning target to {reserved} for {function_name}")
         response = client.put_provisioned_concurrency_config(

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -205,7 +205,8 @@ def enable_provisioned_concurrency(event, context):
     list_of_functions = [f"aqts-capture-discrete-loader-{STAGE}-loadDiscrete"]
 
     for function_name in list_of_functions:
-        #response = client.get_alias()
+        response = client.get_function(FunctionName=function_name)
+        print(response)
         response = client.put_provisioned_concurrency_config(
             FunctionName=function_name,
             Qualifier='$LATEST',

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -225,7 +225,7 @@ def enable_provisioned_concurrency(event, context):
         response = client.put_provisioned_concurrency_config(
             FunctionName=function_name,
             Qualifier=latest_version,
-            ProvisionedConcurrentExecutions=1
+            ProvisionedConcurrentExecutions=10
         )
         logger.info(f"enabling_provisioned_concurrency:\n {response}")
 

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -199,6 +199,32 @@ def grow_observations_db(event, context):
             logger.info(f"Growing observations DB, please stand by. {response}")
 
 
+def enable_provisioned_concurrency(event, context):
+    client = boto3.client('lambda', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
+
+    list_of_functions = [f"aqts-capture-discrete-loader-{STAGE}-loadDiscrete"]
+
+    for function_name in list_of_functions:
+        response = client.put_provisioned_concurrency_config(
+            FunctionName=function_name,
+            Qualifier='LATEST',
+            ProvisionedConcurrentExecutions=1
+        )
+        print(response)
+
+
+def disable_provisioned_concurrency(event, context):
+    client = boto3.client('lambda', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
+    list_of_functions = [f"aqts-capture-discrete-loader-{STAGE}-loadDiscrete"]
+
+    for function_name in list_of_functions:
+        response = client.delete_provisioned_concurrency_config(
+            FunctionName=function_name,
+            Qualifier='LATEST'
+        )
+        print(response)
+
+
 def _validate_observations_resize():
     if os.environ['STAGE'] in ('DEV', 'TEST', 'QA'):
         return

--- a/src/handler.py
+++ b/src/handler.py
@@ -78,6 +78,11 @@ DB stop and start functions
 """
 
 
+def execute_start_machine(event, context):
+    arn = os.environ['START_STATE_MACHINE_ARN']
+    _execute_start_machine(arn, {})
+
+
 def start_capture_db(event, context):
     stage = os.getenv('STAGE')
     if stage in STAGES:

--- a/src/handler.py
+++ b/src/handler.py
@@ -80,7 +80,8 @@ DB stop and start functions
 
 def execute_start_machine(event, context):
     arn = os.environ['START_STATE_MACHINE_ARN']
-    _execute_state_machine(arn, "")
+    empty_payload = {}
+    _execute_state_machine(arn, json.dumps(empty_payload))
 
 
 def start_capture_db(event, context):

--- a/src/handler.py
+++ b/src/handler.py
@@ -4,7 +4,7 @@ import os
 
 import boto3
 
-from src.db_resize_handler import disable_trigger, enable_trigger, execute_recover_machine
+from src.db_resize_handler import disable_trigger, enable_trigger, execute_recover_machine, _execute_state_machine
 from src.rds import RDS
 from src.utils import enable_lambda_trigger, describe_db_clusters, start_db_cluster, disable_lambda_trigger, \
     stop_db_cluster, \

--- a/src/handler.py
+++ b/src/handler.py
@@ -80,7 +80,7 @@ DB stop and start functions
 
 def execute_start_machine(event, context):
     arn = os.environ['START_STATE_MACHINE_ARN']
-    _execute_state_machine(arn, {})
+    _execute_state_machine(arn, "")
 
 
 def start_capture_db(event, context):

--- a/src/handler.py
+++ b/src/handler.py
@@ -4,7 +4,7 @@ import os
 
 import boto3
 
-from src.db_resize_handler import disable_trigger, enable_trigger, execute_recover_machine, _execute_state_machine
+from src.db_resize_handler import disable_trigger, enable_trigger, execute_recover_machine
 from src.rds import RDS
 from src.utils import enable_lambda_trigger, describe_db_clusters, start_db_cluster, disable_lambda_trigger, \
     stop_db_cluster, \
@@ -80,7 +80,7 @@ DB stop and start functions
 
 def execute_start_machine(event, context):
     arn = os.environ['START_STATE_MACHINE_ARN']
-    _execute_start_machine(arn, {})
+    _execute_state_machine(arn, {})
 
 
 def start_capture_db(event, context):
@@ -452,4 +452,13 @@ def _make_kms_key(event):
         AliasName=alias,
         TargetKeyId=response['KeyMetadata']['KeyId']
     )
+
+
+def _execute_state_machine(state_machine_arn, invocation_payload, region='us-west-2'):
+    sf = boto3.client('stepfunctions', region_name=region)
+    resp = sf.start_execution(
+        stateMachineArn=state_machine_arn,
+        input=invocation_payload
+    )
+    return resp
 

--- a/src/tests/test_db_resize_handler.py
+++ b/src/tests/test_db_resize_handler.py
@@ -397,4 +397,4 @@ class TestDbResizeHandler(TestCase):
 
         db_resize_handler.disable_provisioned_concurrency({}, {})
         self.assertEqual(mock_client.list_versions_by_function.call_count, 15)
-        self.assertEqual(mock_client.delete_provisioned_concurrency_config.call_count, 15)
+        self.assertEqual(mock_client.delete_provisioned_concurrency_config.call_count, 45)

--- a/src/tests/test_db_resize_handler.py
+++ b/src/tests/test_db_resize_handler.py
@@ -381,7 +381,7 @@ class TestDbResizeHandler(TestCase):
     def test_enable_provisioned_concurrency(self, mock_boto3):
         mock_client = mock.Mock()
         mock_client.list_versions_by_function.return_value = VERSION_RESPONSE
-        mock_client.get_function_concurrency.return_value = {'ReservedConcurrentExecutions': 10}
+        mock_client.get_function_concurrency.return_value = {'ReservedConcurrentExecutions': 25}
         mock_boto3.return_value = mock_client
 
         db_resize_handler.enable_provisioned_concurrency({}, {})

--- a/src/tests/test_db_resize_handler.py
+++ b/src/tests/test_db_resize_handler.py
@@ -381,7 +381,7 @@ class TestDbResizeHandler(TestCase):
     def test_enable_provisioned_concurrency(self, mock_boto3):
         mock_client = mock.Mock()
         mock_client.list_versions_by_function.return_value = VERSION_RESPONSE
-        mock_client.get_function_concurrency.return_value = {'ReservedConcurrentExecutions': '10'}
+        mock_client.get_function_concurrency.return_value = {'ReservedConcurrentExecutions': 10}
         mock_boto3.return_value = mock_client
 
         db_resize_handler.enable_provisioned_concurrency({}, {})

--- a/src/tests/test_db_resize_handler.py
+++ b/src/tests/test_db_resize_handler.py
@@ -381,11 +381,13 @@ class TestDbResizeHandler(TestCase):
     def test_enable_provisioned_concurrency(self, mock_boto3):
         mock_client = mock.Mock()
         mock_client.list_versions_by_function.return_value = VERSION_RESPONSE
+        mock_client.get_function_concurrency.return_value = {'ReservedConcurrentExecutions': '10'}
         mock_boto3.return_value = mock_client
 
         db_resize_handler.enable_provisioned_concurrency({}, {})
         self.assertEqual(mock_client.list_versions_by_function.call_count, 15)
         self.assertEqual(mock_client.put_provisioned_concurrency_config.call_count, 15)
+        self.assertEqual(mock_client.get_function_concurrency.call_count, 15)
 
     @mock.patch('src.utils.boto3.client', autospec=True)
     def test_disable_provisioned_concurrency(self, mock_boto3):

--- a/src/tests/test_handler.py
+++ b/src/tests/test_handler.py
@@ -400,14 +400,14 @@ class TestHandler(TestCase):
             Description='test security group', GroupName='my group', VpcId='fsa12345'
         )
 
-
-    @mock.patch('src.handler.purge_queue', autospec=True)
-    def test_create_efs_access_point(self, mock_purge):
-
-        handler.troubleshoot(
-            {"action": "purge_queues"},
-            self.context
-        )
-
-        self.assertEqual(mock_purge.purge_queue.call_count, 2)
+    # @mock.patch('src.utils.boto3.client', autospec=True)
+    # def test_purge_queues(self, mock_purge):
+    #     mock_client = mock.Mock()
+    #     mock_purge.return_value = mock_client()
+    #     handler.troubleshoot(
+    #         {"action": "purge_queues"},
+    #         self.context
+    #     )
+    #
+    #     self.assertEqual(mock_purge.purge_queue.call_count, 2)
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Investigate if using provisioned concurrency will get rid of our concurrency flutters when we re-enable the trigger.

Description
-----------
Create two new lambda functions -- enableProvisionedConcurrency and disableProvisionedConcurrency.  Then integrate them into the state machines for shrinking the db, growing the db, and recovering from a circuit breaker (the three cases where we re-enable the trigger).

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
