### PR TITLE
IOW-766 Change circuit breaker so it is not just on/off

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -204,7 +204,7 @@ functions:
       LOG_LEVEL: INFO
       STAGE: ${self:provider.stage}
 
-  circuitBreaker:
+  CircuitBreaker:
     handler: src.handler.circuit_breaker
     role:
       Fn::Sub:
@@ -729,12 +729,12 @@ resources:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: ${self:service}-${self:provider.stage}-circuit-breaker-alarm
-        AlarmDescription: Notify when the db control utilization lambda is invoked
+        AlarmDescription: Notify when the circuit breaker lambda is invoked
         Namespace: 'AWS/Lambda'
         Dimensions:
           - Name: FunctionName
             Value:
-              Ref: ControlDbUtilLambdaFunction
+              Ref: CircuitBreakerFunction
         MetricName: ConcurrentExecutions
         Statistic: Maximum
         ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/serverless.yml
+++ b/serverless.yml
@@ -734,7 +734,7 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value:
-              Ref: CircuitBreakerFunction
+              Ref: CircuitBreakerLambdaFunction
         MetricName: ConcurrentExecutions
         Statistic: Maximum
         ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/serverless.yml
+++ b/serverless.yml
@@ -209,7 +209,6 @@ functions:
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       LOG_LEVEL: INFO
       STAGE: ${self:provider.stage}
-      RECOVER_STATE_MACHINE_ARN: arn:aws:states:${self:provider.region}:#{AWS::AccountId}:stateMachine:aqts-ecosystem-switch-recover-${self:provider.stage}
     events:
       - cloudwatchEvent:
           event:
@@ -608,44 +607,6 @@ stepFunctions:
           WaitForDisable:
             Type: Wait
             Seconds: 300
-            Next: GrowDb
-          GrowDb:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [ growDb, Arn ]
-            Retry:
-              - ErrorEquals:
-                  - States.ALL
-                IntervalSeconds: 120
-                MaxAttempts: 10
-                BackoffRate: 1
-            Next: WaitForModify
-          WaitForModify:
-            Type: Wait
-            Seconds: 600
-            Next: EnableTrigger
-          EnableTrigger:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [ enableTrigger, Arn ]
-            Retry:
-              - ErrorEquals:
-                  - States.ALL
-                IntervalSeconds: 120
-                MaxAttempts: 10
-                BackoffRate: 1
-            End: true
-
-    aqtsRecoverFromCircuitBreaker:
-      role: arn:aws:iam::#{AWS::AccountId}:role/step-functions-service-access
-      name: aqts-ecosystem-switch-recover-${self:provider.stage}
-      definition:
-        Comment: "AQTS Recover From Circuit Breaker"
-        StartAt: WaitForBackoffPurposes
-        States:
-          WaitForBackoffPurposes:
-            Type: Wait
-            Seconds: 7200
             Next: GrowDb
           GrowDb:
             Type: Task

--- a/serverless.yml
+++ b/serverless.yml
@@ -204,8 +204,8 @@ functions:
       LOG_LEVEL: INFO
       STAGE: ${self:provider.stage}
 
-  ControlDbUtil:
-    handler: src.handler.control_db_utilization
+  circuitBreaker:
+    handler: src.handler.circuit_breaker
     role:
       Fn::Sub:
         - arn:aws:iam::${accountId}:role/csr-Lambda-Role

--- a/src/db_resize_handler.py
+++ b/src/db_resize_handler.py
@@ -100,13 +100,6 @@ def execute_grow_machine(event, context):
     return False
 
 
-def execute_recover_machine(event, context):
-    arn = os.environ['RECOVER_STATE_MACHINE_ARN']
-    payload = {}
-    _execute_state_machine(arn, json.dumps(payload))
-
-
-
 def _get_cpu_utilization(db_instance_identifier, period_in_seconds, total_time):
     response = cloudwatch_client.get_metric_data(
         MetricDataQueries=[

--- a/src/handler.py
+++ b/src/handler.py
@@ -175,6 +175,8 @@ def circuit_breaker(event, context):
 
 
 def adjust_flow_rate(new_flow_rate):
+    if new_flow_rate is None or new_flow_rate < 0 or new_flow_rate > 25:
+        raise Exception(f"flow rate must be between 0 and 25")
     client = boto3.client('lambda', os.getenv('AWS_DEPLOYMENT_REGION'))
     response = client.put_function_concurrency(
         FunctionName=TRIGGER[STAGE][0],
@@ -257,6 +259,8 @@ def troubleshoot(event, context):
         _change_secret_kms_key(event)
     elif event['action'].lower() == 'change_kms_key_policy':
         _change_kms_key_policy(event)
+    elif event['action'].lower() == 'change_flow_rate':
+        adjust_flow_rate(event['flow_rate'])
     # TODO remove
     elif event['action'].lower() == 'delete_stack':
         stack = event['stack']

--- a/src/tests/test_handler.py
+++ b/src/tests/test_handler.py
@@ -136,7 +136,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.adjust_flow_rate')
     def test_control_db_utilization_enable_lambda_trigger_when_db_on(self, mock_adjust, mock_get_flow,
                                                                      mock_describe_db_clusters):
-        mock_get_flow.return_value = 25
+        mock_get_flow.return_value = 15
         my_alarm = {
             "detail": {
                 "state": {
@@ -159,7 +159,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
     def test_control_db_utilization_enable(self, mock_adjust, mock_get_flow):
-        mock_get_flow.return_value = 25
+        mock_get_flow.return_value = 15
         my_alarm = {
             "detail": {
                 "state": {

--- a/src/tests/test_handler.py
+++ b/src/tests/test_handler.py
@@ -135,7 +135,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.describe_db_clusters')
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_ramp_25_to_15(
+    def test_circuit_breaker_ramp_25_to_15(
             self, mock_adjust, mock_get_flow, mock_describe_db_clusters):
 
         # Test where we ramp down from 25
@@ -149,7 +149,7 @@ class TestHandler(TestCase):
         }
         os.environ['STAGE'] = 'TEST'
         mock_describe_db_clusters.return_value = DB['TEST']
-        handler.control_db_utilization(my_alarm, self.context)
+        handler.circuit_breaker(my_alarm, self.context)
         mock_get_flow.assert_called_once()
         mock_adjust.assert_called_once_with(15)
 
@@ -157,7 +157,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.describe_db_clusters')
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_ramp_15_to_0(
+    def test_circuit_breaker_ramp_15_to_0(
             self, mock_adjust, mock_get_flow, mock_describe_db_clusters):
 
         # Test where we ramp down from 15
@@ -171,7 +171,7 @@ class TestHandler(TestCase):
         }
         os.environ['STAGE'] = 'TEST'
         mock_describe_db_clusters.return_value = DB['TEST']
-        handler.control_db_utilization(my_alarm, self.context)
+        handler.circuit_breaker(my_alarm, self.context)
         mock_get_flow.assert_called_once()
         mock_adjust.assert_called_once_with(0)
 
@@ -179,7 +179,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.describe_db_clusters')
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_ramp_0_to_0(
+    def test_circuit_breaker_ramp_0_to_0(
             self, mock_adjust, mock_get_flow, mock_describe_db_clusters):
 
         # Test where we ramp down from 0
@@ -193,7 +193,7 @@ class TestHandler(TestCase):
         }
         os.environ['STAGE'] = 'TEST'
         mock_describe_db_clusters.return_value = DB['TEST']
-        handler.control_db_utilization(my_alarm, self.context)
+        handler.circuit_breaker(my_alarm, self.context)
         mock_get_flow.assert_called_once()
         mock_adjust.assert_not_called()
 
@@ -202,7 +202,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.describe_db_clusters')
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_ramp_0_to_15(
+    def test_circuit_breaker_ramp_0_to_15(
             self, mock_adjust, mock_get_flow, mock_describe_db_clusters):
 
         # Test where we ramp from zero
@@ -216,7 +216,7 @@ class TestHandler(TestCase):
         }
         os.environ['STAGE'] = 'TEST'
         mock_describe_db_clusters.return_value = DB['TEST']
-        handler.control_db_utilization(my_alarm, self.context)
+        handler.circuit_breaker(my_alarm, self.context)
         mock_get_flow.assert_called_once()
         mock_adjust.assert_called_once_with(15)
 
@@ -224,7 +224,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.describe_db_clusters')
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_ramp_15_to_25(
+    def test_circuit_breaker_ramp_15_to_25(
             self, mock_adjust, mock_get_flow, mock_describe_db_clusters):
 
         # Test where we ramp from zero
@@ -238,7 +238,7 @@ class TestHandler(TestCase):
         }
         os.environ['STAGE'] = 'TEST'
         mock_describe_db_clusters.return_value = DB['TEST']
-        handler.control_db_utilization(my_alarm, self.context)
+        handler.circuit_breaker(my_alarm, self.context)
         mock_get_flow.assert_called_once()
         mock_adjust.assert_called_once_with(25)
 
@@ -247,7 +247,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.describe_db_clusters')
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_ramp_25_to_25(
+    def test_circuit_breaker_ramp_25_to_25(
             self, mock_adjust, mock_get_flow, mock_describe_db_clusters):
 
         # Test where we ramp from zero
@@ -261,7 +261,7 @@ class TestHandler(TestCase):
         }
         os.environ['STAGE'] = 'TEST'
         mock_describe_db_clusters.return_value = DB['TEST']
-        handler.control_db_utilization(my_alarm, self.context)
+        handler.circuit_breaker(my_alarm, self.context)
         mock_get_flow.assert_called_once()
         mock_adjust.assert_not_called()
 
@@ -270,7 +270,7 @@ class TestHandler(TestCase):
     @mock.patch('src.handler.describe_db_clusters')
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_ramp_bogus_flow_rate(
+    def test_circuit_breaker_ramp_bogus_flow_rate(
             self, mock_adjust, mock_get_flow, mock_describe_db_clusters):
         my_alarm = {
             "detail": {
@@ -283,74 +283,18 @@ class TestHandler(TestCase):
         os.environ['STAGE'] = 'TEST'
         mock_get_flow.return_value = 9000
         with self.assertRaises(Exception) as context:
-            handler.control_db_utilization(my_alarm, self.context)
+            handler.circuit_breaker(my_alarm, self.context)
 
     @mock.patch.dict('src.utils.os.environ', mock_env_vars)
     @mock.patch('src.handler.describe_db_clusters')
     @mock.patch('src.handler.get_flow_rate')
     @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_bogus_stage(
+    def test_circuit_breaker_bogus_stage(
             self, mock_adjust, mock_get_flow, mock_describe_db_clusters):
 
         os.environ['STAGE'] = 'UNKNOWN'
         with self.assertRaises(Exception) as context:
-            handler.control_db_utilization(self.initial_event, self.context)
-
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.get_flow_rate')
-    @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_enable(self, mock_adjust, mock_get_flow):
-        mock_get_flow.return_value = 15
-        my_alarm = {
-            "detail": {
-                "state": {
-                    "value": "OK",
-                }
-            }
-        }
-        for stage in STAGES:
-            os.environ['STAGE'] = stage
-            handler.control_db_utilization(my_alarm, self.context)
-            # TODO
-            # mock_execute_recover_machine.assert_called_with({}, {})
-
-        os.environ['STAGE'] = 'UNKNOWN'
-        with self.assertRaises(Exception) as context:
-            handler.control_db_utilization(self.initial_event, self.context)
-
-    @mock.patch.dict('src.utils.os.environ', mock_env_vars)
-    @mock.patch('src.handler.get_flow_rate')
-    @mock.patch('src.handler.adjust_flow_rate')
-    def test_control_db_utilization_disable(self, mock_adjust, mock_get_flow):
-        mock_get_flow.return_value = 25
-        my_alarm = {
-            "detail": {
-                "state": {
-                    "value": "ALARM",
-                }
-            }
-        }
-        for stage in STAGES:
-            os.environ['STAGE'] = stage
-            handler.control_db_utilization(my_alarm, self.context)
-            mock_adjust.assert_called_with(15)
-
-        mock_get_flow.return_value = 15
-        my_alarm = {
-            "detail": {
-                "state": {
-                    "value": "ALARM",
-                }
-            }
-        }
-        for stage in STAGES:
-            os.environ['STAGE'] = stage
-            handler.control_db_utilization(my_alarm, self.context)
-            mock_adjust.assert_called_with(0)
-
-        os.environ['STAGE'] = 'UNKNOWN'
-        with self.assertRaises(Exception) as context:
-            handler.control_db_utilization(self.initial_event, self.context)
+            handler.circuit_breaker(self.initial_event, self.context)
 
     @mock.patch('src.handler.disable_lambda_trigger', autospec=True)
     @mock.patch('src.handler.run_etl_query')


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Change circuit breaker to dynamically alter reserved concurrency

Description
-----------
The prevision implementation of the circuit breaker enabled and disabled the trigger, which lead to concurrency spikes when the trigger got enabled and we had a lot of cold starts.   For IOW-766 I looked at using provisioned concurrency original, but it doesn't appear to fix any of our problems and causes new problems of its own, so I abandoned that and am trying to change the circuit breaker to dial the data level up and down instead of on off.

If we are running full blast (reservedConcurrency==25) and the errorHandler alarm goes off signaling that the system is in bad shape, change the reservedConcurrency to 15.  This will take some pressure of the system while keeping all the lambdas hot, and maintaining enough activity so the database doesn't shrink.  If this is not adequate and the errorHandler fires again, then set the reservedConcurrency to zero.  This is functionally equivalent to disabling the trigger.

Similarly, the errorHandler alarm can send multiple OK and INSUFFICIENT_DATA messages with send an alarm.  If we are in a maximum alarm state (reservedConcurrency==0) and we get a non-alarm signal, increase the concurrency to 15.  This gets the system warming up and doing useful work.  At some point we will get a second signal and increase to the max, 25.

I'm not sure how this will work when we test it out, but putting in review in case you guys see anything obviously wrong or don't like the idea.  Jenkins is broken at the moment, and we are going to get hit with all the reservedConcurrencies being applied to lambdas for IOW-781 while this idea is being tested out.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
