### PR TITLE
IOW-711 Observations database on dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,15 @@ aqts-capture-ecosystem-switch-<STAGE>-executeShrink
 aqts-capture-ecosystem-switch-<STAGE>-executeGrow
 ```
 
-## What if I need to prevent automatic shutdown of nwcapture-test for a long running test?
+## Updating the observations database on DEV
 
-1. AWS Console->Event Bridge->Events->Rules->aqts-capture-ecosystem-switch-sw-stoptest->Disable
-2. Remember to enable again when your test is concluded.
+```
+1.  Take a manual snapshot of the production observations db in the AWS Console
+2.  Use the rundeck job "share_rds_snapshot" to share this production snapshot with the dev account
+3.  Run the troubleshoot lambda in the dev account with the 'copy_dev_snapshot' action, providing the
+    arn of the shared production snapshot and the namee for the new manual snapshot in the dev account
+4.  Update the serverless.yml environment variable LAST_OB_DB_SNAPSHOT with the name of the new manual snapshot
+```
 
 ## Advanced troubleshooting
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -50,22 +50,22 @@ custom:
     QA: true
     PROD-EXTERNAL: false
   startObservationSchedules:
-    DEV: cron(59 12 ? * MON *)
+    DEV: cron(59 12 ? * MON-FRI *)
     TEST: cron(59 12 ? * MON-FRI *)
     QA: cron(59 12 ? * MON *)
     PROD-EXTERNAL: cron(0 12 ? * MON *)
   stopObservationSchedules:
-    DEV: cron(59 23 ? * FRI *)
+    DEV: cron(59 23 ? * MON-FRI *)
     TEST: cron(59 23 ? * MON-FRI *)
     QA: cron(59 23 ? * FRI *)
     PROD-EXTERNAL: cron(0 23 ? * FRI *)
   startCaptureSchedules:
-    DEV: cron(59 12 ? * MON *)
+    DEV: cron(59 12 ? * MON-FRI *)
     TEST: cron(59 12 ? * MON-FRI *)
     QA: cron(59 12 ? * MON *)
     PROD-EXTERNAL: cron(0 12 ? * MON *)
   stopCaptureSchedules:
-    DEV: cron(59 23 ? * FRI *)
+    DEV: cron(59 23 ? * MON-FRI *)
     TEST: cron(59 23 ? * MON-FRI *)
     QA: cron(59 23 ? * FRI *)
     PROD-EXTERNAL: cron(59 23 ? * FRI *)
@@ -77,7 +77,7 @@ custom:
     QA: false
     PROD-EXTERNAL: false
   startObservationDbScheduleEnabled:
-    DEV: false
+    DEV: true
     TEST: true
     QA: false
     PROD-EXTERNAL: false
@@ -89,7 +89,7 @@ custom:
   stopObservationDbScheduleEnabled:
     DEV: true
     TEST: true
-    QA: true
+    QA: false
     PROD-EXTERNAL: false
 
   exportGitVariables: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -416,6 +416,9 @@ functions:
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       CAN_DELETE_DB: ${self:custom.canDeleteDb.${self:provider.stage}}
       STAGE: ${self:provider.stage}
+      LAST_OB_DB_SNAPSHOT: observations-db-legacy-production-external-2021-01-10-08-33
+
+
       LOG_LEVEL: INFO
 
   deleteObservationDb:

--- a/serverless.yml
+++ b/serverless.yml
@@ -77,7 +77,7 @@ custom:
     QA: false
     PROD-EXTERNAL: false
   startObservationDbScheduleEnabled:
-    DEV: true
+    DEV: false
     TEST: true
     QA: false
     PROD-EXTERNAL: false

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -221,7 +221,9 @@ def create_observation_db(event, context):
     )
     secret_string = json.loads(original['SecretString'])
     subgroup_name = str(secret_string['DB_SUBGROUP_NAME'])
+    logger.info(f"subnet group is {subgroup_name}")
     vpc_security_group_id = str(secret_string['VPC_SECURITY_GROUP_ID'])
+    logger.info(f"vpc security group = {vpc_security_group_id}")
     my_snapshot_identifier = _get_observation_snapshot_identifier()
     logger.info(f"my snapshot identified {my_snapshot_identifier}")
 
@@ -238,8 +240,8 @@ def create_observation_db(event, context):
             vpc_security_group_id,
         ],
         Tags=OBSERVATION_INSTANCE_TAGS
-
     )
+    logger.info(response)
 
 
 def delete_observation_db(event, context):
@@ -317,7 +319,8 @@ def modify_observation_passwords(event, context):
 def _get_observation_snapshot_identifier():
     # In the dev account we don't have a list of automatic backups
     # See README
-    if os.getenv('LAST_OB_DB_SNAPSHOT') is not None:
+    if os.getenv('LAST_OB_DB_SNAPSHOT') is not None and STAGE.lower() == 'dev':
+        logger.info(f"returning devs last snapshot {os.getenv('LAST_OB_DB_SNAPSHOT')}")
         return os.getenv('LAST_OB_DB_SNAPSHOT')
     two_days_ago = datetime.datetime.now() - datetime.timedelta(2)
     date_str = _get_date_string(two_days_ago)

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -11,24 +11,28 @@ import logging
 
 STAGES = ['TEST', 'QA', 'PROD-EXTERNAL']
 DB = {
+    "DEV": 'nwcapture-dev',
     "TEST": 'nwcapture-test',
     "QA": 'nwcapture-qa',
     "PROD-EXTERNAL": 'aqts-capture-db-legacy-production-external'
 }
 
 OBSERVATIONS_DB = {
+    "DEV": 'observations-dev',
     "TEST": 'observations-test',
     "QA": 'observations-qa',
     "PROD-EXTERNAL": 'observations-db-legacy-production-external'
 }
 
 SQS = {
+    "DEV": ['aqts-capture-trigger-queue-DEV', 'aqts-capture-error-queue-DEV'],
     "TEST": ['aqts-capture-trigger-queue-TEST', 'aqts-capture-error-queue-TEST'],
     "QA": ['aqts-capture-trigger-queue-QA', 'aqts-capture-error-queue-QA'],
     "PROD-EXTERNAL": ['aqts-capture-trigger-queue-PROD-EXTERNAL']
 }
 
 TRIGGER = {
+    "DEV": ['aqts-capture-trigger-DEV-aqtsCaptureTrigger'],
     "TEST": ['aqts-capture-trigger-TEST-aqtsCaptureTrigger'],
     "QA": ['aqts-capture-trigger-QA-aqtsCaptureTrigger'],
     "PROD-EXTERNAL": ['aqts-capture-trigger-PROD-EXTERNAL-aqtsCaptureTrigger']
@@ -117,9 +121,7 @@ def delete_capture_db(event, context):
 
 
 def create_db_instance(event, context):
-    _validate()
-    logger.info("enter create db instance")
-    logger.info(event)
+    _validate()(event)
     stage = os.environ['STAGE'].lower()
     rds_client.create_db_instance(
         DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,
@@ -132,8 +134,6 @@ def create_db_instance(event, context):
 
 def restore_db_cluster(event, context):
     _validate()
-    logger.info("enter restore db cluster")
-    logger.info(event)
 
     original = secrets_client.get_secret_value(
         SecretId=CAPTURE_DB_SECRET_KEY
@@ -177,7 +177,6 @@ def restore_db_cluster(event, context):
 
 def modify_schema_owner_password(event, context):
     _validate()
-    logger.info(event)
     """
     We don't know the password for 'capture_owner' on the production db,
     but we have already changed the postgres password in the modifyDbCluster step.
@@ -214,29 +213,22 @@ def get_snapshot_identifier():
 
 def create_observation_db(event, context):
     _validate()
-    logger.info(f"event {event}")
 
     original = secrets_client.get_secret_value(
         SecretId=OBSERVATION_REAL
     )
     secret_string = json.loads(original['SecretString'])
     subgroup_name = str(secret_string['DB_SUBGROUP_NAME'])
-    logger.info(f"subnet group is {subgroup_name}")
     vpc_security_group_id = str(secret_string['VPC_SECURITY_GROUP_ID'])
-    logger.info(f"vpc security group = {vpc_security_group_id}")
     my_snapshot_identifier = _get_observation_snapshot_identifier()
-    logger.info(f"my snapshot identified {my_snapshot_identifier}")
-
-    #client = boto3.client('ec2', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
-    #response = client.describe_subnets()
-    #logger.info(response)
-
+    database_name = secret_string['DATABASE_NAME']
     response = rds_client.restore_db_instance_from_db_snapshot(
         DBInstanceIdentifier=f"observations-{STAGE.lower()}",
         DBSnapshotIdentifier=my_snapshot_identifier,
         DBInstanceClass='db.r5.2xlarge',
         Port=5432,
         DBSubnetGroupName=subgroup_name,
+        DatabaseName=database_name,
         Iops=0,
         MultiAZ=False,
         Engine='postgres',
@@ -245,7 +237,6 @@ def create_observation_db(event, context):
         ],
         Tags=OBSERVATION_INSTANCE_TAGS
     )
-    logger.info(response)
 
 
 def delete_observation_db(event, context):
@@ -261,7 +252,6 @@ def delete_observation_db(event, context):
 
 def modify_observation_postgres_password(event, context):
     _validate()
-    logger.info(event)
     original = secrets_client.get_secret_value(
         SecretId=OBSERVATION_REAL,
     )
@@ -277,18 +267,14 @@ def modify_observation_postgres_password(event, context):
 
 def modify_observation_passwords(event, context):
     _validate()
-    logger.info(event)
     original = secrets_client.get_secret_value(
         SecretId=OBSERVATION_REAL,
     )
     secret_string = json.loads(original['SecretString'])
     db_host = secret_string['DATABASE_ADDRESS']
     db_name = secret_string['DATABASE_NAME']
-    logger.info(f"db_host {db_host} db_name {db_name}")
     postgres_password = secret_string['POSTGRES_PASSWORD']
-    logger.info(f"postgres password {postgres_password}")
     rds = RDS(db_host, 'postgres', db_name, postgres_password)
-    logger.info("got rds ok")
     pwd = secret_string['DB_OWNER_PASSWORD']
     sql = "alter user wqp_core with password %s"
     rds.alter_permissions(sql, (pwd,))
@@ -325,13 +311,11 @@ def _get_observation_snapshot_identifier():
     # In the dev account we don't have a list of automatic backups
     # See README
     if os.getenv('LAST_OB_DB_SNAPSHOT') is not None and STAGE.lower() == 'dev':
-        logger.info(f"returning devs last snapshot {os.getenv('LAST_OB_DB_SNAPSHOT')}")
         return os.getenv('LAST_OB_DB_SNAPSHOT')
     two_days_ago = datetime.datetime.now() - datetime.timedelta(2)
     date_str = _get_date_string(two_days_ago)
     response = rds_client.describe_db_snapshots(
-        DBInstanceIdentifier='observations-db-legacy-production-external',
-        SnapshotType='automated')
+        DBInstanceIdentifier='observations-db-legacy-production-external')
     for snapshot in response['DBSnapshots']:
         if date_str in snapshot['DBSnapshotIdentifier'] \
                 and "observations-db-legacy-production-external" in snapshot['DBSnapshotIdentifier']:

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -236,7 +236,6 @@ def create_observation_db(event, context):
         DBSnapshotIdentifier=my_snapshot_identifier,
         DBInstanceClass='db.r5.2xlarge',
         Port=5432,
-        DBSubnetGroupName=subgroup_name,
         Iops=0,
         MultiAZ=False,
         Engine='postgres',

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -221,7 +221,6 @@ def create_observation_db(event, context):
     )
     secret_string = json.loads(original['SecretString'])
     subgroup_name = str(secret_string['DB_SUBGROUP_NAME'])
-    subgroup_name = 'csr-vpc-internal-Subnet-A'
     logger.info(f"subnet group is {subgroup_name}")
     vpc_security_group_id = str(secret_string['VPC_SECURITY_GROUP_ID'])
     logger.info(f"vpc security group = {vpc_security_group_id}")

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -227,6 +227,10 @@ def create_observation_db(event, context):
     my_snapshot_identifier = _get_observation_snapshot_identifier()
     logger.info(f"my snapshot identified {my_snapshot_identifier}")
 
+    client = boto3.client('ec2', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
+    response = client.describe_subnets()
+    logger.info(response)
+
     response = rds_client.restore_db_instance_from_db_snapshot(
         DBInstanceIdentifier=f"observations-{STAGE.lower()}",
         DBSnapshotIdentifier=my_snapshot_identifier,

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -121,7 +121,7 @@ def delete_capture_db(event, context):
 
 
 def create_db_instance(event, context):
-    _validate()(event)
+    _validate()
     stage = os.environ['STAGE'].lower()
     rds_client.create_db_instance(
         DBInstanceIdentifier=DEFAULT_DB_INSTANCE_IDENTIFIER,

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -221,21 +221,23 @@ def create_observation_db(event, context):
     )
     secret_string = json.loads(original['SecretString'])
     subgroup_name = str(secret_string['DB_SUBGROUP_NAME'])
+    subgroup_name = 'csr-vpc-internal-Subnet-A'
     logger.info(f"subnet group is {subgroup_name}")
     vpc_security_group_id = str(secret_string['VPC_SECURITY_GROUP_ID'])
     logger.info(f"vpc security group = {vpc_security_group_id}")
     my_snapshot_identifier = _get_observation_snapshot_identifier()
     logger.info(f"my snapshot identified {my_snapshot_identifier}")
 
-    client = boto3.client('ec2', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
-    response = client.describe_subnets()
-    logger.info(response)
+    #client = boto3.client('ec2', os.getenv('AWS_DEPLOYMENT_REGION', 'us-west-2'))
+    #response = client.describe_subnets()
+    #logger.info(response)
 
     response = rds_client.restore_db_instance_from_db_snapshot(
         DBInstanceIdentifier=f"observations-{STAGE.lower()}",
         DBSnapshotIdentifier=my_snapshot_identifier,
         DBInstanceClass='db.r5.2xlarge',
         Port=5432,
+        DBSubnetGroupName=subgroup_name,
         Iops=0,
         MultiAZ=False,
         Engine='postgres',

--- a/src/db_create_handler.py
+++ b/src/db_create_handler.py
@@ -284,8 +284,9 @@ def modify_observation_passwords(event, context):
     secret_string = json.loads(original['SecretString'])
     db_host = secret_string['DATABASE_ADDRESS']
     db_name = secret_string['DATABASE_NAME']
+    logger.info(f"db_host {db_host} db_name {db_name}")
     postgres_password = secret_string['POSTGRES_PASSWORD']
-
+    logger.info(f"postgres password {postgres_password}")
     rds = RDS(db_host, 'postgres', db_name, postgres_password)
     logger.info("got rds ok")
     pwd = secret_string['DB_OWNER_PASSWORD']

--- a/src/handler.py
+++ b/src/handler.py
@@ -297,7 +297,7 @@ def troubleshoot(event, context):
             SourceDBSnapshotIdentifier=shared_arn,
             TargetDBSnapshotIdentifier=new_snapshot_identifier,
         )
-    elif event['action'].lower() == 'delete_db_snapshot':
+    elif event['action'].lower() == 'delete_dev_snapshot':
         snapshot_to_delete = event['snapshot_identifier']
         response = rds_client.delete_db_snapshot(
             DBSnapshotIdentifier=snapshot_to_delete

--- a/src/handler.py
+++ b/src/handler.py
@@ -290,6 +290,18 @@ def troubleshoot(event, context):
         # here and specify the access point id.  Don't check into master
         client = boto3.client('efs', os.getenv('AWS_DEPLOYMENT_REGION'))
         client.delete_access_point(AccessPointId='fsap-xxxxxxxxxxxxxxxxx')
+    elif event['action'].lower() == 'copy_dev_snapshot':
+        shared_arn = event['shared_arn']
+        new_snapshot_identifier = event['new_snapshot_identifier']
+        response = rds_client.copy_db_snapshot(
+            SourceDBSnapshotIdentifier=shared_arn,
+            TargetDBSnapshotIdentifier=new_snapshot_identifier,
+        )
+    elif event['action'].lower() == 'delete_db_snapshot':
+        snapshot_to_delete = event['snapshot_identifier']
+        response = rds_client.delete_db_snapshot(
+            DBSnapshotIdentifier=snapshot_to_delete
+        )
     else:
         raise Exception(f"invalid action")
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -12,27 +12,31 @@ from src.utils import enable_lambda_trigger, describe_db_clusters, start_db_clus
     get_capture_db_cluster_identifier, get_capture_db_instance_identifier
 import logging
 
-STAGES = ['TEST', 'QA', 'PROD-EXTERNAL']
+STAGES = ['DEV', 'TEST', 'QA', 'PROD-EXTERNAL']
 
 DB = {
+    "DEV": 'nwcapture-dev',
     "TEST": 'nwcapture-test',
     "QA": 'nwcapture-qa',
     "PROD-EXTERNAL": 'aqts-capture-db-legacy-production-external'
 }
 
 OBSERVATIONS_DB = {
+    "DEV": 'observations-dev',
     "TEST": 'observations-test',
     "QA": 'observations-qa',
     "PROD-EXTERNAL": 'observations-db-legacy-production-external'
 }
 
 SQS = {
+    "DEV": ['aqts-capture-trigger-queue-DEV', 'aqts-capture-error-queue-DEV'],
     "TEST": ['aqts-capture-trigger-queue-TEST', 'aqts-capture-error-queue-TEST'],
     "QA": ['aqts-capture-trigger-queue-QA', 'aqts-capture-error-queue-QA'],
     "PROD-EXTERNAL": ['aqts-capture-trigger-queue-PROD-EXTERNAL']
 }
 
 TRIGGER = {
+    "DEV": ['aqts-capture-trigger-DEV-aqtsCaptureTrigger'],
     "TEST": ['aqts-capture-trigger-TEST-aqtsCaptureTrigger'],
     "QA": ['aqts-capture-trigger-QA-aqtsCaptureTrigger'],
     "PROD-EXTERNAL": ['aqts-capture-trigger-PROD-EXTERNAL-aqtsCaptureTrigger']

--- a/src/tests/test_db_create_handler.py
+++ b/src/tests/test_db_create_handler.py
@@ -247,7 +247,8 @@ class TestDbCreateHandler(TestCase):
             {
                 "KMS_KEY_ID": "kms",
                 "DB_SUBGROUP_NAME": "subgroup",
-                "VPC_SECURITY_GROUP_ID": "vpc_id"
+                "VPC_SECURITY_GROUP_ID": "vpc_id",
+                "DATABASE_NAME": "dbname"
             }
         )
         mock_secret_payload = {


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Make observations db available in the dev account.

Description
-----------
We have to do some manual steps to get a copy of a production snapshot into the dev account.  After that, the normal createObservationsLambda will work the way it normally does.

Right now the db is stopped.  It has to be started by invoking the start lambda.  If someone does start it, it will stop automatically at 6 pm central.  This schedule is temporary until we get some assets in the dev account that can use the db.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
